### PR TITLE
Do not split command input on comma

### DIFF
--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -52,7 +52,7 @@ class Occ {
 	 */
 	public function execute() {
 		$command = $this->request->getParam("command", "");
-		$args = \preg_split("/[\s,]+/", $command);
+		$args = \preg_split("/[\s]+/", $command);
 		$args = \array_map(
 			function ($arg) {
 				return \escapeshellarg($arg);


### PR DESCRIPTION
The code to receive a request for an ``occ`` command first escapes each of the parameters, in order to protect against callers trying to do extra tricky bash things.

The code splits the command by both whitespace and comma.

We do not want to split by comma, because a single command argument might have a real, ordinary, comma in it. e.g. the ``config:system:set`` command is getting an option that takes a JSON string. The JSON string often has commas in it. We do not want to mess that up.