### PR TITLE
Add endpoints sysinfo, dir and file

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -26,6 +26,8 @@ use OCA\Testing\Config;
 use OCA\Testing\Locking\Provisioning;
 use OCA\Testing\Occ;
 use OCA\Testing\Notifications;
+use OCA\Testing\ServerFiles;
+use OCA\Testing\SysInfo;
 use OCP\API;
 use OCA\Testing\Opcache;
 use OCA\Testing\Logfile;
@@ -169,6 +171,36 @@ API::register(
 	'delete',
 	'/apps/testing/api/v1/logfile',
 	[$logFile, 'clear'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+$sysInfo = new SysInfo();
+
+API::register(
+	'get',
+	'/apps/testing/api/v1/sysinfo',
+	[$sysInfo, 'read'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+$serverFiles = new ServerFiles(
+	\OC::$server->getRequest()
+);
+
+API::register(
+	'post',
+	'/apps/testing/api/v1/dir',
+	[$serverFiles, 'mkDir'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+API::register(
+	'post',
+	'/apps/testing/api/v1/file',
+	[$serverFiles, 'createFile'],
 	'testing',
 	API::ADMIN_AUTH
 );

--- a/lib/ServerFiles.php
+++ b/lib/ServerFiles.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Phil Davis <phil@jankaritech.com>
+ * @copyright Copyright (c) 2018 Phil Davis phil@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OC\OCS\Result;
+use OCP\IConfig;
+use OCP\IRequest;
+
+/**
+ *
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * manipulate files and folders on the server
+ */
+class ServerFiles {
+	/**
+	 * @var IRequest
+	 */
+	private $request;
+
+	/**
+	 * @param IConfig $config
+	 * @param IRequest $request
+	 */
+	public function __construct(IRequest $request) {
+		$this->request = $request;
+	}
+
+	/**
+	 * Create the specified directory under the server root
+	 *
+	 * 'dir' is the directory to create, which may be inside other directories
+	 * e.g. 'apps2/myapp/appinfo'
+	 *
+	 * @return Result
+	 */
+	public function mkDir() {
+		$dir = \trim($this->request->getParam('dir'), '/');
+		$targetDir = \OC::$SERVERROOT . "/$dir";
+		if (!\file_exists($targetDir)) {
+			// Ask for the full mode, it will be masked by the current umask anyway
+			// Create recursively so that multiple levels of directory can be
+			// created at once.
+			\mkdir($targetDir, 0777, true);
+		}
+
+		return new Result();
+	}
+
+	/**
+	 * Create the specified file under the server root
+	 *
+	 * 'file' is the file to create, including path from the server root
+	 * e.g. 'apps2/myapp/appinfo/info.xml'
+	 * 'content' is the data to write into the file
+	 *
+	 * @return Result
+	 */
+	public function createFile() {
+		$filePath = \trim($this->request->getParam('file'), '/');
+		$content = $this->request->getParam('content');
+		$targetFile = \OC::$SERVERROOT . "/$filePath";
+		\file_put_contents($targetFile, $content);
+
+		return new Result();
+	}
+}

--- a/lib/SysInfo.php
+++ b/lib/SysInfo.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Phil Davis <phil@jankaritech.com>
+ * @copyright Copyright (c) 2018 Phil Davis phil@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OC\OCS\Result;
+
+/**
+ *
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * access system information
+ */
+class SysInfo {
+
+	/**
+	 * gathers and returns internal system information
+	 *
+	 * @return Result
+	 */
+	public function read() {
+		$sysInfo = [];
+		$sysInfo['server_root'] = $this->getServerRoot();
+		return new Result($sysInfo, 100);
+	}
+
+	/**
+	 *
+	 * @return string
+	 */
+	private function getServerRoot() {
+		return \OC::$SERVERROOT;
+	}
+}


### PR DESCRIPTION
## Description
Add 3 endpoints for:

1) ``sysinfo`` - return system information about the "inside" of the server-under-test. Initially this returns just the server-root path, which we want to know in order to calculate and set the ``apps_paths`` config parameter usefully during tests. In future this can easily be expanded to return whatever else is needed that is not available via existing methods such as ``capabilities`` and ``config:system:get``

2) ``dir`` - a POST to this endpoint will create the requested directory under the existing server root. e.g. we can create a 2nd apps dir called ``apps2`` and some app folder structure inside that. In future this could be expanded so that a GET returns a list of files in the directory, for example.

3) ``files`` - a POST to this endpoint will create the requested file (if it does not already exist) and write the specified content to the file. e.g. we can write a file ``apps2/myapp/appinfo/info.xml`` to "create" a dummy app. In  future this could be expanded so that a GET returns the content of the requested file.

These endpoints, like the existing testing app endpoint for doing ``occ`` commands... open up the server to being managed remotely pretty much as if the remote admin user had a command line prompt on the server. That is why **the testing app should not be installed/enabled on a production system**. But also note that the testing app endpoints only work when admin authentication is given.

## Issue
https://github.com/owncloud/core/issues/32459

## How has this been tested

Modified core ``AppManagementContext.php`` to use these new endpoints. Run core ``tests/acceptance/features/apiMain/appmanagement.feature`` locally and confirm it passes.
Proposed core code is in core PR https://github.com/owncloud/core/pull/32458