### PR TITLE
Support passing env variables with occ commands

### DIFF
--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -52,6 +52,8 @@ class Occ {
 	 */
 	public function execute() {
 		$command = $this->request->getParam("command", "");
+		$envVariables = $this->request->getParam("env_variables", []);
+
 		$args = \preg_split("/[\s]+/", $command);
 		$args = \array_map(
 			function ($arg) {
@@ -65,11 +67,13 @@ class Occ {
 			1 => ['pipe', 'w'],
 			2 => ['pipe', 'w'],
 		];
+
 		$process = \proc_open(
 			'php console.php ' . $args,
 			$descriptor,
 			$pipes,
-			\realpath("../")
+			\realpath("../"),
+			$envVariables
 		);
 		$lastStdOut = \stream_get_contents($pipes[1]);
 		$lastStdErr = \stream_get_contents($pipes[2]);
@@ -79,9 +83,9 @@ class Occ {
 			"stdOut" => $lastStdOut,
 			"stdErr" => $lastStdErr
 		];
-		
+
 		$resultCode = $lastCode + 100;
-		
+
 		return new Result($result, $resultCode);
 	}
 }


### PR DESCRIPTION
See description in core PR https://github.com/owncloud/core/pull/32574

In particular, we need to be able to pass across the ``OC_PASS`` env variable when using the ``occ user:add`` command.

This will help us have tests for various ``occ`` commands that use env variables for some parameters.

At first it will be used by password policy tests, that need to run ``occ user:add`` with various passwords.