### PR TITLE
allow to slowdown dav requests

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,6 +10,12 @@
 		<owncloud min-version="10.0" max-version="10.1" />
 	</dependencies>
 	<types>
+		<dav/>
 		<authentication/>
 	</types>
+	<sabre>
+		<plugins>
+			<plugin>OCA\Testing\Dav\SlowdownPlugin</plugin>
+		</plugins>
+	</sabre>
 </info>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -31,6 +31,7 @@ use OCA\Testing\SysInfo;
 use OCP\API;
 use OCA\Testing\Opcache;
 use OCA\Testing\Logfile;
+use OCA\Testing\DavSlowdown;
 
 $config = new Config(
 	\OC::$server->getConfig(),
@@ -201,6 +202,16 @@ API::register(
 	'post',
 	'/apps/testing/api/v1/file',
 	[$serverFiles, 'createFile'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+$davSlowDown = new DavSlowdown();
+
+API::register(
+	'put',
+	'/apps/testing/api/v1/davslowdown/{method}/{seconds}',
+	[$davSlowDown, 'setSlowdown'],
 	'testing',
 	API::ADMIN_AUTH
 );

--- a/lib/Dav/SlowdownPlugin.php
+++ b/lib/Dav/SlowdownPlugin.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing\Dav;
+
+use OCP\ILogger;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+
+/**
+ * Sabre plugin for the the file firewall:
+ */
+class SlowdownPlugin extends ServerPlugin {
+	const NS_OWNCLOUD = 'http://owncloud.org/ns';
+
+	/**
+	 * @var Server $server
+	 */
+	private $server;
+
+	/**
+	 * @var ILogger
+	 */
+	private $logger;
+
+	/**
+	 * SlowdownPlugin plugin
+	 *
+	 * @param ILogger $logger
+	 */
+	public function __construct(ILogger $logger) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * registers an event for every method mentioned in 'dav.slowdown' setting
+	 *
+	 * @param Server $server
+	 *
+	 * @return void
+	 */
+	public function initialize(Server $server) {
+		$this->server = $server;
+		$slowDown = \OC::$server->getConfig()->getSystemValue('dav.slowdown', '{}');
+		$this->slowDownSettings = \json_decode($slowDown, true);
+		foreach ($this->slowDownSettings as $method => $seconds) {
+			$this->server->on("method:$method", [$this, 'sleep'], 90);
+		}
+	}
+
+	/**
+	 *
+	 * @param RequestInterface $request request object
+	 * @param ResponseInterface $response response object
+	 * @throws \Sabre\DAV\Exception\Forbidden
+	 * @return boolean
+	 */
+	public function sleep(
+		RequestInterface $request, ResponseInterface $response
+	) {
+		$timeToSleep = $this->slowDownSettings[\strtoupper($request->getMethod())];
+		$this->logger->info("time to sleep $timeToSleep");
+		for ($i = 0; $i <= $timeToSleep; $i++) {
+			$this->logger->info("sleeping $i ...");
+			\sleep(1);
+		}
+	}
+}

--- a/lib/DavSlowdown.php
+++ b/lib/DavSlowdown.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OC\OCS\Result;
+
+/**
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ *
+ */
+class DavSlowdown {
+
+	/**
+	 * save the settings in a system setting
+	 *
+	 * @param array $parameters
+	 *
+	 * @return Result
+	 */
+	public function setSlowdown($parameters) {
+		$method = \strtoupper($parameters['method']);
+		$seconds = (int)$parameters['seconds'];
+		$slowDown = \OC::$server->getConfig()->getSystemValue('dav.slowdown', '{}');
+		$slowDown = \json_decode($slowDown, true);
+		$slowDown[$method] = $seconds;
+		\OC::$server->getConfig()->setSystemValue('dav.slowdown', \json_encode($slowDown));
+		
+		return new Result();
+	}
+}


### PR DESCRIPTION
## Description
this makes is possible to slowdown DAV requests by registering an Event that sleeps for the required time
That will help to test async operations manually and automatically see https://github.com/owncloud/core/pull/31851 and https://github.com/owncloud/core/pull/32414

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)