### PR TITLE
Add capability to delete files and folders

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -215,9 +215,25 @@ API::register(
 );
 
 API::register(
+	'delete',
+	'/apps/testing/api/v1/dir',
+	[$serverFiles, 'rmDir'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+API::register(
 	'post',
 	'/apps/testing/api/v1/file',
 	[$serverFiles, 'createFile'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+API::register(
+	'delete',
+	'/apps/testing/api/v1/file',
+	[$serverFiles, 'deleteFile'],
 	'testing',
 	API::ADMIN_AUTH
 );

--- a/lib/ServerFiles.php
+++ b/lib/ServerFiles.php
@@ -21,9 +21,12 @@
 
 namespace OCA\Testing;
 
+use FilesystemIterator;
 use OC\OCS\Result;
 use OCP\IConfig;
 use OCP\IRequest;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  *
@@ -67,6 +70,42 @@ class ServerFiles {
 	}
 
 	/**
+	 * Delete the specified directory under the server root
+	 *
+	 * 'dir' is the directory to delete, which may be inside other directories
+	 * e.g. 'apps2/myapp/appinfo'
+	 *
+	 * @return Result
+	 */
+	public function rmDir() {
+		$dir = \trim($this->request->getParam('dir'), '/');
+		if ($dir === "") {
+			return new Result(null, 400, "cannot delete dir, no dir name given");
+		}
+		$targetDir = \OC::$SERVERROOT . "/$dir";
+		if (\file_exists($targetDir)) {
+			if (\is_dir($targetDir)) {
+				$di = new RecursiveDirectoryIterator(
+					$targetDir, FilesystemIterator::SKIP_DOTS
+				);
+				$ri = new RecursiveIteratorIterator(
+					$di, RecursiveIteratorIterator::CHILD_FIRST
+				);
+				foreach ($ri as $file) {
+					$file->isDir() ?  \rmdir($file) : \unlink($file);
+				}
+				\rmdir($targetDir);
+			} else {
+				return new Result(null, 400, "$dir is not a directory");
+			}
+		} else {
+			return new Result(null, 400, "$dir does not exist");
+		}
+
+		return new Result();
+	}
+
+	/**
 	 * Create the specified file under the server root
 	 *
 	 * 'file' is the file to create, including path from the server root
@@ -80,6 +119,33 @@ class ServerFiles {
 		$content = $this->request->getParam('content');
 		$targetFile = \OC::$SERVERROOT . "/$filePath";
 		\file_put_contents($targetFile, $content);
+
+		return new Result();
+	}
+
+	/**
+	 * Delete the specified file under the server root
+	 *
+	 * 'file' is the file to delete, including path from the server root
+	 * e.g. 'apps2/myapp/appinfo/info.xml'
+	 *
+	 * @return Result
+	 */
+	public function deleteFile() {
+		$filePath = \trim($this->request->getParam('file'), '/');
+		if ($filePath === "") {
+			return new Result(null, 400, "cannot delete file, no file name given");
+		}
+		$targetFile = \OC::$SERVERROOT . "/$filePath";
+		if (\file_exists($targetFile)) {
+			if (\is_dir($targetFile)) {
+				return new Result(null, 403, "$filePath is a directory");
+			} else {
+				\unlink($targetFile);
+			}
+		} else {
+			return new Result(null, 400, "$filePath does not exist");
+		}
 
 		return new Result();
 	}

--- a/lib/ServerFiles.php
+++ b/lib/ServerFiles.php
@@ -92,9 +92,28 @@ class ServerFiles {
 					$di, RecursiveIteratorIterator::CHILD_FIRST
 				);
 				foreach ($ri as $file) {
-					$file->isDir() ?  \rmdir($file) : \unlink($file);
+					if ($file->isDir()) {
+						if (!\rmdir($file)) {
+							return new Result(
+								null,
+								400,
+								"failed to delete sub-directory $file while deleting $targetDir");
+						}
+					} else {
+						if (!\unlink($file)) {
+							return new Result(
+								null,
+								400,
+								"failed to delete file $file while deleting $targetDir");
+						}
+					}
 				}
-				\rmdir($targetDir);
+				if (!\rmdir($targetDir)) {
+					return new Result(
+						null,
+						400,
+						"failed to delete directory $targetDir");
+				}
 			} else {
 				return new Result(null, 400, "$dir is not a directory");
 			}
@@ -141,7 +160,9 @@ class ServerFiles {
 			if (\is_dir($targetFile)) {
 				return new Result(null, 403, "$filePath is a directory");
 			} else {
-				\unlink($targetFile);
+				if (!\unlink($targetFile)) {
+					return new Result(null, 400, "failed to delete $filePath");
+				}
 			}
 		} else {
 			return new Result(null, 400, "$filePath does not exist");


### PR DESCRIPTION
## Description
Allow the testing app to be used to delete a folder or file on the server.

Currently the test runner can remotely create folders and files on the server, e.g. to be used ffor "local_storage" external storage tests. 

Some test steps want to "pull a file from underneath" in "local_storage" external storage. For that to work on a remote server-under-test, it needs to be done via the testing app.

And to be nice and cleanup the server-under-test after test scenarios, we need to be able to delete the temporary folder(s) that were created.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)