### PR TITLE
Correctly parse occ commands that have quoted strings containing spaces

### DIFF
--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -62,7 +62,17 @@ class Occ {
 		$reqEnvVars = $this->request->getParam("env_variables", []);
 		$envVars = \array_merge($this->getDefaultEnv(), $reqEnvVars);
 
-		$args = \preg_split("/[\s]+/", $command);
+		// Match the pieces of the string that are like:
+		//   Strings with single-quoted parts and there could be space(s) in the
+		//   single-quoted parts:
+		//     --display-name='User One'
+		//     --email='user1@example.org'
+		//   Simple strings like:
+		//     user:add
+		//     user1
+		//     --password-from-env
+		\preg_match_all("/\S*?'[^']*?'|\S+/", $command, $matches);
+		$args = $matches[0];
 		$args = \array_map(
 			function ($arg) {
 				return \escapeshellarg($arg);


### PR DESCRIPTION
## Description
Fall asleep on the keyboard, random keys come out, paste them into a regex, everything works.

Fixes issue #31 

But really, read the issue and the comment that I put in the code above the regex.

It allows password policy tests to pass when creating users with a display name like 'User One' with an ``occ`` command.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)