### PR TITLE
Allow quoted strings in occ commands

### DIFF
--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -75,6 +75,9 @@ class Occ {
 		$args = $matches[0];
 		$args = \array_map(
 			function ($arg) {
+				if ((\substr($arg, 0, 1) === "'") && (\substr($arg, -1) === "'")) {
+					return $arg;
+				}
 				return \escapeshellarg($arg);
 			}, $args
 		);


### PR DESCRIPTION
## Description
We need to be able to specify empty values in occ commands, or values containing spaces:
```
occ config:app:set someapp somesetting --value ''
occ config:app:set someapp somesetting --value ' '
occ config:app:set someapp somesetting --value 'Phil Davis'
```

The current testing app code correctly detects these quoted strings, but then it does ``escapeshellarg`` on them and the value gets set to the whole literal string, including the single quote at each end.

If we send those sort of values without quotes, then it looks like empty space, no space or multiple values in the command line.

So if an element is already surrounded by single quotes, then do not ``escapeshellarg`` it.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)