### PR TITLE
Allow quoted strings like --display-name='User One'

### DIFF
--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -67,6 +67,9 @@ class Occ {
 		//   single-quoted parts:
 		//     --display-name='User One'
 		//     --email='user1@example.org'
+		//     'An already quoted literal value with spaces in it'
+		//     ' '
+		//     ''
 		//   Simple strings like:
 		//     user:add
 		//     user1
@@ -75,7 +78,11 @@ class Occ {
 		$args = $matches[0];
 		$args = \array_map(
 			function ($arg) {
-				if ((\substr($arg, 0, 1) === "'") && (\substr($arg, -1) === "'")) {
+				// if the arg is already surrounded by single-quotes or the arg looks like:
+				//   something='abc'
+				// then do not use escapeshellarg on it.
+				if (((\substr($arg, 0, 1) === "'") || \strpos($arg, "='", 1) !== false)
+					&& (\substr($arg, -1) === "'")) {
 					return $arg;
 				}
 				return \escapeshellarg($arg);


### PR DESCRIPTION
## Description
If we send an occ command fragment like:
```
--display-name='User One'
```

Then we do not want to escape it again, because that ends up creating the user with a display name that includes the single quotes literally at each end of the display name.

The work-around is to send:
```
--display-name 'User One'
```

But we want to be able to use both ways of writing occ commands, without having to think too much when writing tests.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)