### PR TITLE
Add textfile0.txt to webUI skeleton

### DIFF
--- a/data/webUISkeleton/textfile0.txt
+++ b/data/webUISkeleton/textfile0.txt
@@ -1,0 +1,1 @@
+ownCloud test text file 0


### PR DESCRIPTION
## Description
Add ``textfile0.txt`` to the webUI skeleton.

We want to have some file that is identical in both the webUI and API skeleton. That will let use write "generic" test steps that download a file and check its content, that will work the same from API or webUI test scenarios. Such steps are useful for doing a generic test that "the user account is functional".

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)