### PR TITLE
API acceptance tests for serverfiles

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -239,6 +239,14 @@ API::register(
 	API::ADMIN_AUTH
 );
 
+API::register(
+	'get',
+	'/apps/testing/api/v1/file',
+	[$serverFiles, 'readFile'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
 $davSlowDown = new DavSlowdown();
 
 API::register(

--- a/lib/ServerFiles.php
+++ b/lib/ServerFiles.php
@@ -125,6 +125,27 @@ class ServerFiles {
 	}
 
 	/**
+	 * Get the contents of specified file under the server root
+	 *
+	 * 'file' is the file to get, including path from the server root
+	 * e.g. 'apps2/myapp/appinfo/info.xml'
+	 *
+	 * @return Result
+	 */
+	public function readFile() {
+		$filePath = \trim($this->request->getParam('file'), '/');
+		$targetFile = \OC::$SERVERROOT . "/$filePath";
+		if (\file_exists($targetFile)) {
+			$contents = \trim(\file_get_contents($targetFile));
+			$result[] = [
+				'data' => $contents
+			];
+			return new Result($result);
+		}
+		return new Result(null, 404, "$filePath does not exist");
+	}
+
+	/**
 	 * Create the specified file under the server root
 	 *
 	 * 'file' is the file to create, including path from the server root
@@ -137,8 +158,10 @@ class ServerFiles {
 		$filePath = \trim($this->request->getParam('file'), '/');
 		$content = $this->request->getParam('content');
 		$targetFile = \OC::$SERVERROOT . "/$filePath";
-		\file_put_contents($targetFile, $content);
-
+		$result = \file_put_contents($targetFile, $content);
+		if ($result === false) {
+			return new Result(null, 403, "failed to create $targetFile");
+		}
 		return new Result();
 	}
 

--- a/tests/acceptance/features/apiTestingApp/serverFiles.feature
+++ b/tests/acceptance/features/apiTestingApp/serverFiles.feature
@@ -1,0 +1,24 @@
+@api
+Feature: Test ServerFiles feature of testing app
+
+  Scenario Outline: Testing app can create file in server root
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator creates the file "data/loremfile.txt" with content "lorem ipsum" using the testing API
+    Then the file "data/loremfile.txt" with content "lorem ipsum" should exist in the server root
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  Scenario Outline: Testing app can delete file in server root
+    Given using OCS API version "<ocs-api-version>"
+    And the administrator has created the file "data/loremfile.txt" with content "lorem ipsum"
+    When the administrator deletes the file "data/loremfile.txt" using the testing API
+    And the administrator reads the contents of the file "data/loremfile.txt" using the testing API
+    Then the HTTP status code should be "<http-status>"
+    And the HTTP reason phrase should be "<http-reason-phrase>"
+    And the OCS status code should be "<ocs-status>"
+    Examples:
+      | ocs-api-version | ocs-status | http-status | http-reason-phrase |
+      | 1               | 404        | 200         | OK                 |
+      | 2               | 404        | 404         | Not Found          |


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Fix createFile method to handle error properly
- Add readFile method and route
- Add acceptance tests for create and delete serverfiles

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)