### PR TITLE
Add test for create and delete directory in server root

### DIFF
--- a/lib/ServerFiles.php
+++ b/lib/ServerFiles.php
@@ -63,7 +63,10 @@ class ServerFiles {
 			// Ask for the full mode, it will be masked by the current umask anyway
 			// Create recursively so that multiple levels of directory can be
 			// created at once.
-			\mkdir($targetDir, 0777, true);
+			$result = \mkdir($targetDir, 0777, true);
+			if ($result === false) {
+				return new Result(null, 403, "failed to create $targetDir");
+			}
 		}
 
 		return new Result();

--- a/tests/acceptance/features/apiTestingApp/serverFiles.feature
+++ b/tests/acceptance/features/apiTestingApp/serverFiles.feature
@@ -19,3 +19,24 @@ Feature: Test ServerFiles feature of testing app
       | ocs-api-version |
       | 1               |
       | 2               |
+
+  Scenario Outline: Testing app can create directory in server root
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator creates the directory "data/lorem-dir" in server root using the testing API
+    And the administrator creates the file "data/lorem-dir/loremfile.txt" with content "lorem ipsum" using the testing API
+    Then the file "data/lorem-dir/loremfile.txt" with content "lorem ipsum" should exist in the server root
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  Scenario Outline: Testing app can delete directory in server root
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator creates the directory "data/lorem-dir" in server root using the testing API
+    And the administrator creates the file "data/lorem-dir/loremfile.txt" with content "lorem ipsum" using the testing API
+    And the administrator deletes the directory "data/lorem-dir" using the testing API
+    Then the file "data/lorem-dir/loremfile.txt" should not exist in the server root
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |

--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -56,6 +56,13 @@ class TestingAppContext implements Context {
 	private $createdFilePaths = [];
 
 	/**
+	 * List of directories created by the testing app
+	 *
+	 * @var array
+	 */
+	private $createdDirectoryPaths = [];
+
+	/**
 	 * Returns base url for the testing app
 	 *
 	 * @param string $path
@@ -507,6 +514,51 @@ class TestingAppContext implements Context {
 	}
 
 	/**
+	 * @When the administrator creates the directory :dir in server root using the testing API
+	 *
+	 * @param string $dir
+	 *
+	 * @return void
+	 */
+	public function theAdministratorCreatesTheDirectoryInServerRootUsingTheTestingApi($dir) {
+		$user = $this->featureContext->getAdminUsername();
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$this->featureContext->getAdminPassword(),
+			'POST',
+			$this->getBaseUrl("/dir"),
+			['dir'=>$dir],
+			$this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+		if ($response->getStatusCode() === 200) {
+			\array_push($this->createdDirectoryPaths, $dir);
+		}
+	}
+
+	/**
+	 * @When the administrator deletes the directory :dir using the testing API
+	 *
+	 * @param string $dir
+	 *
+	 * @return void
+	 */
+	public function theAdministratorDeletesTheDirectoryUsingTheTestingApi($dir) {
+		$user = $this->featureContext->getAdminUsername();
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$this->featureContext->getAdminPassword(),
+			'DELETE',
+			$this->getBaseUrl("/dir"),
+			['dir'=>$dir],
+			$this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * After Scenario. delete files created while testing
 	 *
 	 * @AfterScenario
@@ -516,6 +568,19 @@ class TestingAppContext implements Context {
 	public function deleteAllCreatedFiles() {
 		foreach ($this->createdFilePaths as $path) {
 			$this->theAdministratorDeletesTheFileUsingTheTestingApi($path);
+		}
+	}
+
+	/**
+	 * After Scenario. delete directories created while testing
+	 *
+	 * @AfterScenario
+	 *
+	 * @return void
+	 */
+	public function deleteAllCreatedDirectories() {
+		foreach ($this->createdDirectoryPaths as $dir) {
+			$this->theAdministratorDeletesTheDirectoryUsingTheTestingApi($dir);
 		}
 	}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add API accpetance test for checking create and delete server directories

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)