### PR TITLE
Return urlEncoded response content

### DIFF
--- a/lib/ServerFiles.php
+++ b/lib/ServerFiles.php
@@ -141,7 +141,7 @@ class ServerFiles {
 		if (\file_exists($targetFile)) {
 			$contents = \trim(\file_get_contents($targetFile));
 			$result[] = [
-				'data' => $contents
+				'contentUrlEncoded' => \rawurlencode($contents)
 			];
 			return new Result($result);
 		}


### PR DESCRIPTION
## Description
Return urlEncoded file content as a normal raw response can break xml format, which makes it harder to parse it.