### PR TITLE
Add API acceptance test for creating and deleting notifications

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -14,6 +14,7 @@ default:
             adminPassword: admin
             regularUserPassword: 123456
             ocPath: apps/testing/api/v1/occ
+        - NotificationsCoreContext:
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/tests/acceptance/features/apiTestingApp/notifications.feature
+++ b/tests/acceptance/features/apiTestingApp/notifications.feature
@@ -1,0 +1,47 @@
+@api @app-required @notifications-app-required
+Feature: Test notifications feature of testing app
+
+  Background:
+    Given the app "notifications" has been enabled
+    And these users have been created:
+      | username |
+      | user0    |
+      | user1    |
+
+  Scenario Outline: Testing app can create notifications for user
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator creates a notification with following details using the testing API
+      | key         | value                      |
+      | subject     | lorem_subject              |
+      | message     | lorem_message              |
+      | user        | user0                      |
+      | object_type | local_share                |
+      | link        | www.lorem-notification.com |
+      | object_id   | 47                         |
+    Then user "user0" should have 1 notifications
+    And the last notification of user "user0" should match these regular expressions
+      | subject     | /^lorem_subject$/              |
+      | message     | /^lorem_message$/              |
+      | link        | /^www.lorem-notification.com$/ |
+      | object_type | /^local_share$/                |
+      | object_id   | /^47$/                         |
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  Scenario Outline: Testing app can delete notifications
+    Given using OCS API version "<ocs-api-version>"
+    And the administrator has created a notification with following details using the testing API
+      | key         | value           |
+      | user        | user0                      |
+    And the administrator has created a notification with following details using the testing API
+      | key         | value           |
+      | user        | user1                      |
+    When the user "user0" deletes all notifications using the testing API
+    Then user "user0" should have 0 notifications
+    And user "user1" should have 0 notifications
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |

--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -559,6 +559,63 @@ class TestingAppContext implements Context {
 	}
 
 	/**
+	 * @When the administrator creates a notification with following details using the testing API
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function theAdministratorCreatesANotification(TableNode $table) {
+		$body_array = [];
+		foreach ($table as $item) {
+			$body_array[$item['key']] = $item['value'];
+		}
+		$user = $this->featureContext->getAdminUsername();
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$this->featureContext->getAdminPassword(),
+			'POST',
+			$this->getBaseUrl("/notifications"),
+			$body_array,
+			$this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @When the user :user deletes all notifications using the testing API
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function theUserDeletesAllNotificationsUsingTheTestingApi($user) {
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			'DELETE',
+			$this->getBaseUrl("/notifications"),
+			[],
+			$this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @Given the administrator has created a notification with following details using the testing API
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasCreatedANotification(TableNode $table) {
+		$this->theAdministratorCreatesANotification($table);
+		PHPUnit_Framework_Assert::assertSame(200, $this->featureContext->getResponse()->getStatusCode());
+	}
+
+	/**
 	 * After Scenario. delete files created while testing
 	 *
 	 * @AfterScenario


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add acceptance tests for checking that the testing app can create a notification and delete all notification

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)