### PR TITLE
Add test to check max file id feature

### DIFF
--- a/tests/acceptance/features/apiTestingApp/testing.feature
+++ b/tests/acceptance/features/apiTestingApp/testing.feature
@@ -97,3 +97,13 @@ Feature: Testing the testing app
       | ocs-api-version | ocs-status | http-status | http-reason-phrase |
       | 1               | 100        | 200         | OK                 |
       | 2               | 200        | 200         | OK                 |
+
+  Scenario Outline: Testing app can change the max file id length
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator increases the max file id size beyond 32 bits using the testing API
+    And the administrator creates the user "user0" using the provisioning API
+    Then the file "/textfile0.txt" should have file id greater than 32 bits for user "user0"
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |

--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -616,6 +616,40 @@ class TestingAppContext implements Context {
 	}
 
 	/**
+	 * @When the administrator increases the max file id size beyond 32 bits using the testing API
+	 *
+	 * @return void
+	 */
+	public function theAdministratorIncreasesTheMaxFileIdSizeBeyond32BitsUsingTheTestingApi() {
+		$user = $this->featureContext->getAdminUsername();
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$this->featureContext->getAdminPassword(),
+			'POST',
+			$this->getBaseUrl("/increasefileid"),
+			[],
+			$this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @Then the file :path should have file id greater than :max bits for user :user
+	 *
+	 * @param string $path
+	 * @param int $max
+	 * @param $string $user
+	 *
+	 * @return void
+	 */
+	public function theFileShouldHaveFileIdGreaterThanBitsForUser($path, $max, $user) {
+		$max_value = \bindec(\str_repeat("1", $max - 1));
+		$currentFileID = $this->featureContext->getFileIdForPath($user, $path);
+		PHPUnit_Framework_Assert::assertGreaterThan($max_value, (int)$currentFileID);
+	}
+
+	/**
 	 * After Scenario. delete files created while testing
 	 *
 	 * @AfterScenario


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add test for increasing max fileid size beyond 32 bits using the testing api

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)