### PR TITLE
Testing app supports any 11.0.0.*

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 	<author>Joas Schilling</author>
 	<version>0.1.0</version>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="11.0.0.0" />
+		<owncloud min-version="10.0" max-version="11.0.0" />
 	</dependencies>
 	<types>
 		<dav/>


### PR DESCRIPTION
## Description
1) The testing app is never "released" in the traditional sense, so there are no "installed copies" of the testing app "out there" on production systems.
2) When core developers need to bump the 4th version in core, e.g. to ``11.0.0.1`` because of a DB migration they have added (or...) then the testing app refuses to install-enable for them in CI

We can "promise" that the testing app works with any core ``11.0.0.*`` because if not, then we just quickly fix it to work.

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)