### PR TITLE
Remove redundant steps from testing app

### DIFF
--- a/tests/acceptance/features/apiTestingApp/testing.feature
+++ b/tests/acceptance/features/apiTestingApp/testing.feature
@@ -40,7 +40,7 @@ Feature: Testing the testing app
     And the HTTP reason phrase should be "<http-reason-phrase>"
     And the OCS status code should be "<ocs-status>"
     And the app "core" should have config key "con"
-    And the config key "con" of app "core" must have value "conkey"
+    And the config key "con" of app "core" should have value "conkey"
     When the administrator deletes the config key "con" in app "core" using the testing API
     Then the HTTP status code should be "<http-status>"
     And the HTTP reason phrase should be "<http-reason-phrase>"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove configkey test steps as they have been moved to core app
Also fix the step changed in core

Fixes #64, #66

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)