### PR TITLE
add --remote for running acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test-php-style-fix: vendor-bin/owncloud-codestyle/vendor
 .PHONY: test-acceptance-api
 test-acceptance-api:        ## Run php-cs-fixer and fix code style issues
 test-acceptance-api: vendor
-	../../tests/acceptance/run.sh --config tests/acceptance/config/behat.yml --type api
+	../../tests/acceptance/run.sh --remote --type api
 
 #
 # Dependency management


### PR DESCRIPTION
## Description
Add the ``--remote`` switch when running acceptance tests. This helps in situations where the system-under-test and the test runner are on different systems, or running as different users. e.g. when a developer is running their server as ``www-data`` and the test runner is running as themselves.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)