### PR TITLE
Implement recent CI-script standards

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ pipeline:
     image: owncloudci/core
     pull: true
     exclude:
-    - apps/testing
+      - apps/testing
     version: ${OC_VERSION}
     db_type: ${DB_TYPE}
     db_name: ${DB_NAME=owncloud}
@@ -25,14 +25,14 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-    - COMPOSER_HOME=/var/www/owncloud/apps/testing/.cache/composer
+      - COMPOSER_HOME=/var/www/owncloud/apps/testing/.cache/composer
     commands:
-    - make vendor
-    - cd /var/www/owncloud/
-    - php occ a:l
-    - php occ config:system:set trusted_domains 1 --value=owncloud
-    - php occ a:e testing
-    - php occ a:l
+      - make vendor
+      - cd /var/www/owncloud/
+      - php occ a:l
+      - php occ config:system:set trusted_domains 1 --value=owncloud
+      - php occ a:e testing
+      - php occ a:l
     when:
       matrix:
         NEED_INSTALL_APP: true
@@ -59,8 +59,8 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
-    - make vendor-bin/php-parallel-lint/vendor
-    - make test-php-lint
+      - make vendor-bin/php-parallel-lint/vendor
+      - make test-php-lint
     when:
       matrix:
         TEST_SUITE: owncloud-coding-standard
@@ -78,10 +78,10 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-    - COVERAGE=${COVERAGE}
+      - COVERAGE=${COVERAGE}
     commands:
-    - if [ -z "${COVERAGE}" ]; then make test-php-unit; fi
-    - if [ "${COVERAGE}" = "true" ]; then make test-php-unit-dbg; fi
+      - if [ -z "${COVERAGE}" ]; then make test-php-unit; fi
+      - if [ "${COVERAGE}" = "true" ]; then make test-php-unit-dbg; fi
     when:
       matrix:
         TEST_SUITE: phpunit
@@ -90,11 +90,11 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-    - TEST_SERVER_URL=http://owncloud
-    - PLATFORM=Linux
-    - BEHAT_SUITE=${BEHAT_SUITE}
+      - TEST_SERVER_URL=http://owncloud
+      - PLATFORM=Linux
+      - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
-    - make test-acceptance-api
+      - make test-acceptance-api
     when:
       matrix:
         TEST_SUITE: api-acceptance
@@ -125,10 +125,10 @@ services:
   mysql:
     image: mysql:5.5
     environment:
-    - MYSQL_USER=autotest
-    - MYSQL_PASSWORD=owncloud
-    - MYSQL_DATABASE=${DB_NAME=owncloud}
-    - MYSQL_ROOT_PASSWORD=owncloud
+      - MYSQL_USER=autotest
+      - MYSQL_PASSWORD=owncloud
+      - MYSQL_DATABASE=${DB_NAME=owncloud}
+      - MYSQL_ROOT_PASSWORD=owncloud
     when:
       matrix:
         DB_TYPE: mysql
@@ -136,9 +136,9 @@ services:
   pgsql:
     image: postgres:9.4
     environment:
-    - POSTGRES_USER=autotest
-    - POSTGRES_PASSWORD=owncloud
-    - POSTGRES_DB=${DB_NAME=owncloud}
+      - POSTGRES_USER=autotest
+      - POSTGRES_PASSWORD=owncloud
+      - POSTGRES_DB=${DB_NAME=owncloud}
     when:
       matrix:
         DB_TYPE: pgsql
@@ -146,9 +146,9 @@ services:
   oci:
     image: deepdiver/docker-oracle-xe-11g
     environment:
-    - ORACLE_USER=system
-    - ORACLE_PASSWORD=oracle
-    - ORACLE_DB=${DB_NAME=owncloud}
+      - ORACLE_USER=system
+      - ORACLE_PASSWORD=oracle
+      - ORACLE_DB=${DB_NAME=owncloud}
     when:
       matrix:
         DB_TYPE: oci
@@ -165,147 +165,147 @@ services:
 
 matrix:
   include:
-  # owncloud-coding-standard
-  - PHP_VERSION: 7.2
-    TEST_SUITE: owncloud-coding-standard
+    # owncloud-coding-standard
+    - PHP_VERSION: 7.2
+      TEST_SUITE: owncloud-coding-standard
 
-  # build
-  - PHP_VERSION: 7.2
-    TEST_SUITE: build
+    # build
+    - PHP_VERSION: 7.2
+      TEST_SUITE: build
 
-  # Unit Tests
-  - PHP_VERSION: 7.1
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: sqlite
-    NEED_CORE: true
+    # Unit Tests
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: sqlite
+      NEED_CORE: true
 
-  - PHP_VERSION: 7.1
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: mysql
-    NEED_CORE: true
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: mysql
+      NEED_CORE: true
 
-  - PHP_VERSION: 7.1
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: pgsql
-    NEED_CORE: true
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: pgsql
+      NEED_CORE: true
 
-  - PHP_VERSION: 7.1
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: oci
-    DB_NAME: XE
-    NEED_CORE: true
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: oci
+      DB_NAME: XE
+      NEED_CORE: true
 
-  - PHP_VERSION: 7.2
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: mysql
-    NEED_CORE: true
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: mysql
+      NEED_CORE: true
 
-  - PHP_VERSION: 5.6
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: sqlite
-    NEED_CORE: true
+    - PHP_VERSION: 5.6
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: sqlite
+      NEED_CORE: true
 
-  - PHP_VERSION: 5.6
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: mysql
-    NEED_CORE: true
+    - PHP_VERSION: 5.6
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: mysql
+      NEED_CORE: true
 
-  - PHP_VERSION: 7.0
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: mysql
-    NEED_CORE: true
+    - PHP_VERSION: 7.0
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: mysql
+      NEED_CORE: true
 
-  - PHP_VERSION: 7.0
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: pgsql
-    NEED_CORE: true
-    COVERAGE: true
+    - PHP_VERSION: 7.0
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: pgsql
+      NEED_CORE: true
+      COVERAGE: true
 
-  - PHP_VERSION: 7.0
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: oci
-    DB_NAME: XE
-    NEED_CORE: true
+    - PHP_VERSION: 7.0
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: oci
+      DB_NAME: XE
+      NEED_CORE: true
 
-  - PHP_VERSION: 7.1
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: mysql
-    NEED_CORE: true
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: mysql
+      NEED_CORE: true
 
-  - PHP_VERSION: 7.2
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: mysql
-    NEED_CORE: true
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: phpunit
+      DB_TYPE: mysql
+      NEED_CORE: true
 
-  # Acceptance Tests
-  - PHP_VERSION: 7.1
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: api-acceptance
-    BEHAT_SUITE: apiTestingApp
-    DB_TYPE: mysql
-    DB_NAME: owncloud
-    NEED_CORE: true
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    # Acceptance Tests
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiTestingApp
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
 
-  - PHP_VERSION: 7.2
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: api-acceptance
-    BEHAT_SUITE: apiTestingApp
-    DB_TYPE: mysql
-    DB_NAME: owncloud
-    NEED_CORE: true
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiTestingApp
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
 
-  - PHP_VERSION: 5.6
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: api-acceptance
-    BEHAT_SUITE: apiTestingApp
-    DB_TYPE: mysql
-    DB_NAME: owncloud
-    NEED_CORE: true
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    - PHP_VERSION: 5.6
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiTestingApp
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
 
-  - PHP_VERSION: 7.0
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: api-acceptance
-    BEHAT_SUITE: apiTestingApp
-    DB_TYPE: mysql
-    DB_NAME: owncloud
-    NEED_CORE: true
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    - PHP_VERSION: 7.0
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiTestingApp
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
 
-  - PHP_VERSION: 7.1
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: api-acceptance
-    BEHAT_SUITE: apiTestingApp
-    DB_TYPE: mysql
-    DB_NAME: owncloud
-    NEED_CORE: true
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiTestingApp
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
 
-  - PHP_VERSION: 7.2
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: api-acceptance
-    BEHAT_SUITE: apiTestingApp
-    DB_TYPE: mysql
-    DB_NAME: owncloud
-    NEED_CORE: true
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiTestingApp
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ branches:
   - master
 
 pipeline:
-  install-server:
+  install-core:
     image: owncloudci/core
     pull: true
     exclude:
@@ -19,7 +19,7 @@ pipeline:
     db_password: owncloud
     when:
       matrix:
-        NEED_SERVER: true
+        NEED_CORE: true
 
   install-app:
     image: owncloudci/php:${PHP_VERSION}
@@ -78,7 +78,6 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-    - PHP_VERSION=${PHP_VERSION}
     - COVERAGE=${COVERAGE}
     commands:
     - if [ -z "${COVERAGE}" ]; then make test-php-unit; fi
@@ -179,65 +178,56 @@ matrix:
     OC_VERSION: daily-master-qa
     TEST_SUITE: phpunit
     DB_TYPE: sqlite
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
 
   - PHP_VERSION: 7.1
     OC_VERSION: daily-master-qa
     TEST_SUITE: phpunit
     DB_TYPE: mysql
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
 
   - PHP_VERSION: 7.1
     OC_VERSION: daily-master-qa
     TEST_SUITE: phpunit
     DB_TYPE: pgsql
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
 
   - PHP_VERSION: 7.1
     OC_VERSION: daily-master-qa
     TEST_SUITE: phpunit
     DB_TYPE: oci
     DB_NAME: XE
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
 
   - PHP_VERSION: 7.2
     OC_VERSION: daily-master-qa
     TEST_SUITE: phpunit
     DB_TYPE: mysql
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
 
   - PHP_VERSION: 5.6
     OC_VERSION: daily-stable10-qa
     TEST_SUITE: phpunit
     DB_TYPE: sqlite
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
 
   - PHP_VERSION: 5.6
     OC_VERSION: daily-stable10-qa
     TEST_SUITE: phpunit
     DB_TYPE: mysql
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
 
   - PHP_VERSION: 7.0
     OC_VERSION: daily-stable10-qa
     TEST_SUITE: phpunit
     DB_TYPE: mysql
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
 
   - PHP_VERSION: 7.0
     OC_VERSION: daily-stable10-qa
     TEST_SUITE: phpunit
     DB_TYPE: pgsql
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
     COVERAGE: true
 
   - PHP_VERSION: 7.0
@@ -245,29 +235,28 @@ matrix:
     TEST_SUITE: phpunit
     DB_TYPE: oci
     DB_NAME: XE
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
 
   - PHP_VERSION: 7.1
     OC_VERSION: daily-stable10-qa
     TEST_SUITE: phpunit
     DB_TYPE: mysql
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
 
   - PHP_VERSION: 7.2
     OC_VERSION: daily-stable10-qa
     TEST_SUITE: phpunit
     DB_TYPE: mysql
-    NEED_SERVER: true
-    NEED_INSTALL_APP: true
+    NEED_CORE: true
 
+  # Acceptance Tests
   - PHP_VERSION: 7.1
     OC_VERSION: daily-master-qa
     TEST_SUITE: api-acceptance
     BEHAT_SUITE: apiTestingApp
     DB_TYPE: mysql
     DB_NAME: owncloud
+    NEED_CORE: true
     NEED_SERVER: true
     NEED_INSTALL_APP: true
 
@@ -277,6 +266,7 @@ matrix:
     BEHAT_SUITE: apiTestingApp
     DB_TYPE: mysql
     DB_NAME: owncloud
+    NEED_CORE: true
     NEED_SERVER: true
     NEED_INSTALL_APP: true
 
@@ -286,6 +276,7 @@ matrix:
     BEHAT_SUITE: apiTestingApp
     DB_TYPE: mysql
     DB_NAME: owncloud
+    NEED_CORE: true
     NEED_SERVER: true
     NEED_INSTALL_APP: true
 
@@ -295,6 +286,7 @@ matrix:
     BEHAT_SUITE: apiTestingApp
     DB_TYPE: mysql
     DB_NAME: owncloud
+    NEED_CORE: true
     NEED_SERVER: true
     NEED_INSTALL_APP: true
 
@@ -304,6 +296,7 @@ matrix:
     BEHAT_SUITE: apiTestingApp
     DB_TYPE: mysql
     DB_NAME: owncloud
+    NEED_CORE: true
     NEED_SERVER: true
     NEED_INSTALL_APP: true
 
@@ -313,5 +306,6 @@ matrix:
     BEHAT_SUITE: apiTestingApp
     DB_TYPE: mysql
     DB_NAME: owncloud
+    NEED_CORE: true
     NEED_SERVER: true
     NEED_INSTALL_APP: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -55,16 +55,6 @@ pipeline:
       matrix:
         NEED_SERVER: true
 
-  owncloud-lint:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - make vendor-bin/php-parallel-lint/vendor
-      - make test-php-lint
-    when:
-      matrix:
-        TEST_SUITE: owncloud-coding-standard
-
   owncloud-coding-standard:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -166,6 +156,9 @@ services:
 matrix:
   include:
     # owncloud-coding-standard
+    - PHP_VERSION: 5.6
+      TEST_SUITE: owncloud-coding-standard
+
     - PHP_VERSION: 7.2
       TEST_SUITE: owncloud-coding-standard
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ all_src=$(src_dirs) $(src_files)
 # bin file definitions
 PHPUNIT=php -d zend.enable_gc=0 ../../lib/composer/bin/phpunit
 PHPUNITDBG=phpdbg -qrr -d memory_limit=4096M -d zend.enable_gc=0 "../../lib/composer/bin/phpunit"
-PHPLINT=php -d zend.enable_gc=0  vendor-bin/php-parallel-lint/vendor/bin/parallel-lint
 PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/php-cs-fixer
 
 # start with displaying help
@@ -57,11 +56,6 @@ test-php-unit-dbg:         ## Run php unit tests using phpdbg
 test-php-unit-dbg: ../../lib/composer/bin/phpunit
 	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
 
-.PHONY: test-php-lint
-test-php-lint:             ## Run phan
-test-php-lint: vendor-bin/php-parallel-lint/vendor
-	$(PHPLINT) appinfo lib locking
-
 .PHONY: test-php-style
 test-php-style:            ## Run php-cs-fixer and check owncloud code-style
 test-php-style: vendor-bin/owncloud-codestyle/vendor
@@ -89,12 +83,6 @@ vendor:
 
 vendor/bamarni/composer-bin-plugin:
 	composer install
-
-vendor-bin/php-parallel-lint/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/php-parallel-lint/composer.lock
-	composer bin php-parallel-lint install --no-progress
-
-vendor-bin/php-parallel-lint/composer.lock: vendor-bin/php-parallel-lint/composer.json
-	@echo php-parallel-lint composer.lock is not up to date.
 
 vendor-bin/owncloud-codestyle/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/owncloud-codestyle/composer.lock
 	composer bin owncloud-codestyle install --no-progress

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,6 @@ PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/ph
 help:
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
 
-
-
 ##
 ## Build targets
 ##--------------------------------------
@@ -52,13 +50,12 @@ package:
 .PHONY: test-php-unit
 test-php-unit:             ## Run php unit tests
 test-php-unit: ../../lib/composer/bin/phpunit
-	$(PHPUNIT) --configuration ./phpunit.xml --testsuite testing-unit
-
+	$(PHPUNIT) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-unit-dbg
 test-php-unit-dbg:         ## Run php unit tests using phpdbg
 test-php-unit-dbg: ../../lib/composer/bin/phpunit
-	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite testing-unit
+	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-lint
 test-php-lint:             ## Run phan

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,7 @@
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
 >
-	<testsuite name='testing-unit'>
+	<testsuite name='unit'>
 		<directory suffix='Test.php'>./tests/unit</directory>
 	</testsuite>
 	<!-- filters for code coverage -->

--- a/vendor-bin/php-parallel-lint/composer.json
+++ b/vendor-bin/php-parallel-lint/composer.json
@@ -1,5 +1,0 @@
-{
-    "require": {
-        "jakub-onderka/php-parallel-lint": "^1.0"
-    }
-}


### PR DESCRIPTION
## Description
Bits and pieces that were done last week in password_policy. Make similar standards here:

- ``NEED_CORE`` for the step that sucks in core
- remove the unneeded ``- PHP_VERSION=${PHP_VERSION}`` for ``phpunit-tests:``
- remove ``NEED_INSTALL_APP`` for PHP unit matrix jobs, it is not needed
- testsuite name in ``phpunit.xml`` can just be ``unit`` like other apps
- lint checks, coding-standard covers it
- do coding-standard for both PHP 5.6 and 7.2, that gets a syntax check for both PHP versions

(note: when ``phan`` comes, that provides PHP syntax checking for PHP 7.* and we will just do coding-standard on PHP 5.6)

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)