### PR TITLE
More flexible Makefile help column format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,14 @@ PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/ph
 .DEFAULT_GOAL := help
 
 help:
-	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | sed -e 's/  */ /' | column -t -s :
 
-##
+##---------------------
 ## Build targets
-##--------------------------------------
+##---------------------
 
 .PHONY: dist
-dist:                       ## Build distribution
+dist: ## Build distribution
 dist: distdir package
 
 .PHONY: distdir
@@ -42,32 +42,32 @@ distdir:
 package:
 	tar -czf $(dist_dir)/$(app_name).tar.gz -C $(dist_dir) $(app_name)
 
-##
+##---------------------
 ## Tests
-##--------------------------------------
+##---------------------
 
 .PHONY: test-php-unit
-test-php-unit:             ## Run php unit tests
+test-php-unit: ## Run php unit tests
 test-php-unit: ../../lib/composer/bin/phpunit
 	$(PHPUNIT) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-unit-dbg
-test-php-unit-dbg:         ## Run php unit tests using phpdbg
+test-php-unit-dbg: ## Run php unit tests using phpdbg
 test-php-unit-dbg: ../../lib/composer/bin/phpunit
 	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-style
-test-php-style:            ## Run php-cs-fixer and check owncloud code-style
+test-php-style: ## Run php-cs-fixer and check owncloud code-style
 test-php-style: vendor-bin/owncloud-codestyle/vendor
 	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes --dry-run
 
 .PHONY: test-php-style-fix
-test-php-style-fix:        ## Run php-cs-fixer and fix code style issues
+test-php-style-fix: ## Run php-cs-fixer and fix code style issues
 test-php-style-fix: vendor-bin/owncloud-codestyle/vendor
 	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes
 
 .PHONY: test-acceptance-api
-test-acceptance-api:        ## Run php-cs-fixer and fix code style issues
+test-acceptance-api: ## Run php-cs-fixer and fix code style issues
 test-acceptance-api: vendor
 	../../tests/acceptance/run.sh --remote --type api
 


### PR DESCRIPTION
## Description
When formatting the ``make help`` output:
- replace multiple spaces by a single space
- use the ``column`` command to line up the ``Makefile`` targets and descriptions into columns

At the moment we have to get the correct number of spaces in each ``test-xyz:        ## Description of command`` line.

After this change, we can put whatever spaces we like before and after the ``##`` and the ``make help`` still lines up.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)