### PR TITLE
Add endpoint for getExtension from MimeType

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -86,6 +86,22 @@ API::register(
 	API::ADMIN_AUTH
 );
 
+API::register(
+	'get',
+	'/apps/testing/api/v1/getextension/{type}',
+	[$config, 'getExtensionForMimeType'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+API::register(
+	'get',
+	'/apps/testing/api/v1/getextension/{type}/{subtype}',
+	[$config, 'getExtensionForMimeTypeSubType'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
 $locking = new Provisioning(
 	\OC::$server->getLockingProvider(),
 	\OC::$server->getDatabaseConnection(),

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -22,8 +22,9 @@
 namespace OCA\Testing;
 
 use OCP\IConfig;
-use OC\OCS\Result;
 use OCP\IRequest;
+use OC\OCS\Result;
+use OC\Files\Type\Detection;
 
 class Config {
 
@@ -149,5 +150,56 @@ class Config {
 		}
 
 		return new Result($result);
+	}
+
+	/**
+	 * @param array $parameters
+	 *
+	 * @return Result
+	 */
+	public function getExtensionForMimeType($parameters) {
+		$extensions = [];
+		$mimeTypeList = $this->getAllMimeList();
+		$mimeTypeNeedle = $parameters['type'];
+		foreach ($mimeTypeList as $extension => $mimeType) {
+			if (\explode("/", $mimeType[0])[0] === $mimeTypeNeedle) {
+				$extensions[] = $extension;
+			}
+		}
+		return new Result($extensions);
+	}
+
+	/**
+	 * @param array $parameters
+	 *
+	 * @return Result
+	 */
+	public function getExtensionForMimeTypeSubType($parameters) {
+		$extensions = [];
+		$mimeTypeList = $this->getAllMimeList();
+		$mimeTypeNeedle = $parameters['type'] . '/' . $parameters['subtype'];
+		foreach ($mimeTypeList as $extension => $mimeType) {
+			if ($mimeType[0] === $mimeTypeNeedle) {
+				$extensions[] = $extension;
+			}
+		}
+		return new Result($extensions);
+	}
+
+	/**
+	 * get all mime list
+	 *
+	 * @return array
+	 */
+	public function getAllMimeList() {
+		$configDir = \OC::$SERVERROOT . '/config/';
+		$config = new \OC\Config($configDir);
+		$server = new \OC\Server(\OC::$WEBROOT, $config);
+		$detection = new Detection(
+			$server->getURLGenerator(),
+			$configDir,
+			\OC::$SERVERROOT . '/resources/config/'
+		);
+		return $detection->getAllMappings();
 	}
 }

--- a/tests/acceptance/features/apiTestingApp/testing.feature
+++ b/tests/acceptance/features/apiTestingApp/testing.feature
@@ -133,3 +133,27 @@ Feature: Testing the testing app
       | ocs-api-version | ocs-status | http-status | http-reason-phrase |
       | 1               | 100        | 200         | OK                 |
       | 2               | 200        | 200         | OK                 |
+
+  Scenario Outline: Testing app returns all the extensions of a mime type
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator gets all the extensions of mime-type "audio" using the testing API
+    Then the extensions returned should be "flac, m4a, m4b, mp3, m3u, m3u8, oga, ogg, opus, pls, wav"
+    And the HTTP reason phrase should be "<http-reason-phrase>"
+    And the OCS status code should be "<ocs-status>"
+    And the OCS status code should be "<ocs-status>"
+    Examples:
+      | ocs-api-version | ocs-status | http-status | http-reason-phrase |
+      | 1               | 100        | 200         | OK                 |
+      | 2               | 200        | 200         | OK                 |
+
+  Scenario Outline: Testing app returns all the extensions of a mime type with subtype
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator gets all the extensions of mime-type "audio/ogg" using the testing API
+    Then the extensions returned should be "oga, ogg, opus"
+    And the HTTP reason phrase should be "<http-reason-phrase>"
+    And the OCS status code should be "<ocs-status>"
+    And the OCS status code should be "<ocs-status>"
+    Examples:
+      | ocs-api-version | ocs-status | http-status | http-reason-phrase |
+      | 1               | 100        | 200         | OK                 |
+      | 2               | 200        | 200         | OK                 |

--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -530,6 +530,27 @@ class TestingAppContext implements Context {
 	}
 
 	/**
+	 * @When the administrator gets all the extensions of mime-type :mimetype using the testing API
+	 *
+	 * @param string $mimetype
+	 *
+	 * @return void
+	 */
+	public function theAdministratorGetsAllTheExtensionsOfMimeTypeUsingTheTestingApi($mimetype) {
+		$extensions = [];
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			'GET',
+			"/apps/testing/api/v1/getextension/$mimetype",
+			null,
+			$this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * @Then file :path should have file id greater than :max bits for user :user
 	 *
 	 * @param string $path
@@ -592,6 +613,26 @@ class TestingAppContext implements Context {
 		$this->getLogfile();
 		$finalCount = \count($this->featureContext->getResponseXml()->data[0]);
 		PHPUnit_Framework_Assert::assertLessThan($initialCount, $finalCount);
+	}
+
+	/**
+	 * @Then the extensions returned should be :extensions
+	 *
+	 * @param string $extensions seperated by comma
+	 *
+	 * @return void
+	 */
+	public function theExtensionsReturnedShouldBe($extensions) {
+		$responseXml = HttpRequestHelper::getResponseXml(
+			$this->featureContext->getResponse()
+		);
+		$actualExtensions = \json_decode(\json_encode(
+			$responseXml->data[0]), true
+		);
+		$expectedExtensions = \explode(', ', $extensions);
+		PHPUnit_Framework_Assert::assertEquals(
+			$expectedExtensions, $actualExtensions['element']
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Add an endpoint to getExtenstion from Mime type.
Acceptance tests in  `firewall` app require to get the extension based on the given mimetype. Which requires to load `Config.php` which makes it difficult to run acceptance tests through make command without sudo.
So, this PR solves the issue.

## Related Issue
https://github.com/owncloud/QA/issues/605

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

