### PR TITLE
Change invokingTheCommand to runOcc

### DIFF
--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -271,8 +271,8 @@ class TestingAppContext implements Context {
 		}
 
 		if (isset($appName, $version)) {
-			$this->featureContext->invokingTheCommand(
-				"config:list $appName"
+			$this->featureContext->runOcc(
+				["config:list $appName"]
 			);
 			$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 			$lastOutputArray = \json_decode($lastOutput, true);


### PR DESCRIPTION
## Description
``invokingTheCommand`` just calls ``runOcc`` directly anyway.

https://github.com/owncloud/core/pull/34127 is going to move ``invokingTheCommand`` out of ``FeatureContext`` so ``invokingTheCommand`` will not be there any more.

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)