### PR TITLE
Delete build and vendor when doing make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,15 @@ help:
 ##---------------------
 
 .PHONY: clean
-clean: clean-deps
+clean: clean-build clean-deps
+
+.PHONY: clean-build
+clean-build:
+	rm -Rf $(build_dir)
 
 .PHONY: clean-deps
 clean-deps:
+	rm -Rf vendor
 	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
 
 .PHONY: dist


### PR DESCRIPTION
## Description
1) When doing ``clean`` also delete the ``vendor`` dir
2) There is a ``make dist`` (even though we do not use it). Also provide a ``clean-build`` to delete these files - like is done for other apps.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)