### PR TITLE
new endpoint to work with skeletondirectories used for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test-php-unit-dbg: ../../lib/composer/bin/phpunit
 test-php-style: ## Run php-cs-fixer and check owncloud code-style
 test-php-style: vendor-bin/owncloud-codestyle/vendor vendor-bin/php_codesniffer/vendor
 	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes --dry-run
-	$(PHP_CODESNIFFER) --runtime-set ignore_warnings_on_exit --standard=phpcs.xml tests/acceptance lib/Command
+	$(PHP_CODESNIFFER) --runtime-set ignore_warnings_on_exit --standard=phpcs.xml tests/acceptance lib/Command lib/TestingSkeletonDirectory.php
 
 .PHONY: test-php-style-fix
 test-php-style-fix: ## Run php-cs-fixer and fix code style issues

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -32,6 +32,7 @@ use OCA\Testing\Opcache;
 use OCA\Testing\ServerFiles;
 use OCA\Testing\SysInfo;
 use OCP\API;
+use OCA\Testing\TestingSkeletonDirectory;
 
 $config = new Config(
 	\OC::$server->getConfig(),
@@ -269,6 +270,24 @@ API::register(
 	'put',
 	'/apps/testing/api/v1/davslowdown/{method}/{seconds}',
 	[$davSlowDown, 'setSlowdown'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+$skeletonDirectory = new TestingSkeletonDirectory(\OC::$server->getRequest());
+
+API::register(
+	'get',
+	'/apps/testing/api/v1/testingskeletondirectory',
+	[$skeletonDirectory, 'get'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+API::register(
+	'post',
+	'/apps/testing/api/v1/testingskeletondirectory',
+	[$skeletonDirectory, 'set'],
 	'testing',
 	API::ADMIN_AUTH
 );

--- a/lib/TestingSkeletonDirectory.php
+++ b/lib/TestingSkeletonDirectory.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2019 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OCP\IRequest;
+use OC\Files\Filesystem;
+use OC\OCS\Result;
+
+/**
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ *
+ */
+class TestingSkeletonDirectory {
+	/**
+	 * @var IRequest
+	 */
+	private $request;
+	
+	/**
+	 * @param IRequest $request
+	 */
+	public function __construct(IRequest $request) {
+		$this->request = $request;
+	}
+
+	/**
+	 * returns the root directory of the skeleton directories for various tests
+	 *
+	 * @return Result
+	 */
+	public function get() {
+		return new Result(['rootdirectory' => \realpath(__DIR__ . "/../data/")]);
+	}
+
+	/**
+	 * set a folder below the data folder as skeleton directory
+	 *
+	 * @return Result
+	 */
+	public function set() {
+		$folder = \trim($this->request->getParam('directory'), '/');
+		$folder = Filesystem::normalizePath($folder, true);
+		if (Filesystem::isValidPath($folder) === false) {
+			return new Result(null, 400, "invalid folder name");
+		}
+		$fullPath = \realpath(__DIR__ . "/../data/$folder");
+		if ($fullPath === false || !\file_exists($fullPath)) {
+			return new Result(null, 404, "skeleton directory not found");
+		}
+		\OC::$server->getConfig()->setSystemValue('skeletondirectory', $fullPath);
+		return new Result();
+	}
+}


### PR DESCRIPTION
## Description
endpoint to get the root of testing skeleton directories  and to set a skeleton directory below that root

only the SUT knows its true full path of the skeleton directory, it cannot be guessed by the test runner see: https://github.com/owncloud/core/issues/34483

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)