### PR TITLE
delete skeletondirectory setting before setting it

### DIFF
--- a/lib/TestingSkeletonDirectory.php
+++ b/lib/TestingSkeletonDirectory.php
@@ -67,6 +67,7 @@ class TestingSkeletonDirectory {
 		if ($fullPath === false || !\file_exists($fullPath)) {
 			return new Result(null, 404, "skeleton directory not found");
 		}
+		\OC::$server->getConfig()->deleteSystemValue('skeletondirectory');
 		\OC::$server->getConfig()->setSystemValue('skeletondirectory', $fullPath);
 		return new Result();
 	}


### PR DESCRIPTION
## Description
delete the value before setting it. There seems to be sometimes problems to set the setting to the same value that was set before

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)