### PR TITLE
Drop PHP 5.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -181,7 +181,7 @@ services:
 matrix:
   include:
     # owncloud-coding-standard
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       TEST_SUITE: owncloud-coding-standard
 
     # phpstan
@@ -229,16 +229,10 @@ matrix:
       NEED_CORE: true
       PHAN: true
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: phpunit
       DB_TYPE: sqlite
-      NEED_CORE: true
-
-    - PHP_VERSION: 5.6
-      OC_VERSION: daily-stable10-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: mysql
       NEED_CORE: true
 
     - PHP_VERSION: 7.0
@@ -287,16 +281,6 @@ matrix:
 
     - PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiTestingApp
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 5.6
-      OC_VERSION: daily-stable10-qa
       TEST_SUITE: api-acceptance
       BEHAT_SUITE: apiTestingApp
       DB_TYPE: mysql


### PR DESCRIPTION
## Description
core stable10 no longer supports PHP 5.6
https://github.com/owncloud/core/pull/34698

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)