### PR TITLE
Adjust composer files for 'drop PHP 5.6'

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "5.6.33"
+            "php": "7.0.8"
         }
     },
     "require": {


### PR DESCRIPTION
## Description
I adjusted the `behat/composer.json` 
I did not adjust `info.xml` min-version, because we only have a "latest" testing app tag. The testing app will still work fine on a 10.0 or 10.1 core system. So we do not need to artificially stop that from being possible.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)