### PR TITLE
Phpunit 5 6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "a1f4c002bfc144d81b235e34066bb3d4",
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "62fef740245a85f00665e81ea8f0aa0b72afe6e7"
+                "reference": "67f9d314dc7ecf7245b8637906e151ccc62b8d24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/62fef740245a85f00665e81ea8f0aa0b72afe6e7",
-                "reference": "62fef740245a85f00665e81ea8f0aa0b72afe6e7",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/67f9d314dc7ecf7245b8637906e151ccc62b8d24",
+                "reference": "67f9d314dc7ecf7245b8637906e151ccc62b8d24",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             },
             "require-dev": {
                 "composer/composer": "dev-master",
-                "symfony/console": "^2.5 || ^3.0"
+                "symfony/console": "^2.5 || ^3.0 || ^4.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -44,7 +44,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2017-09-11T13:13:58+00:00"
+            "time": "2019-03-17T12:38:04+00:00"
         }
     ],
     "aliases": [],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="./tests/bootstrap.php"
-		 verbose="true" failOnWarning="true" strict="true"
+		 verbose="true"
+		 strict="true"
+		 failOnRisky="true"
+		 failOnWarning="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"

--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -25,6 +25,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
@@ -188,8 +189,8 @@ class TestingAppContext implements Context {
 		$responseXml = $this->featureContext->getResponseXml();
 		$data = \json_decode(\json_encode($responseXml->data[0]), 1);
 
-		PHPUnit_Framework_Assert::assertInternalType('string', $data['server_root']);
-		PHPUnit_Framework_Assert::assertRegExp('/[^\0]+/', $data['server_root']);
+		Assert::assertInternalType('string', $data['server_root']);
+		Assert::assertRegExp('/[^\0]+/', $data['server_root']);
 	}
 
 	/**
@@ -251,7 +252,7 @@ class TestingAppContext implements Context {
 	 */
 	public function theAdministratorHasAddedTheseConfigKeys(TableNode $table) {
 		$this->theAdministratorAddsTheseConfigKeysUsingTheTestingApi($table);
-		PHPUnit_Framework_Assert::assertSame(200, $this->featureContext->getResponse()->getStatusCode());
+		Assert::assertSame(200, $this->featureContext->getResponse()->getStatusCode());
 	}
 
 	/**
@@ -278,7 +279,7 @@ class TestingAppContext implements Context {
 			$lastOutputArray = \json_decode($lastOutput, true);
 			$app_version = $lastOutputArray['apps'][$appName]['installed_version'];
 
-			PHPUnit_Framework_Assert::assertSame($app_version, $version);
+			Assert::assertSame($app_version, $version);
 		} else {
 			throw new \Exception("Version info could not be found in the response.");
 		}
@@ -295,7 +296,7 @@ class TestingAppContext implements Context {
 		$data = $this->featureContext->parseConfigListFromResponseXml($this->featureContext->getResponseXml());
 		foreach ($data as $element) {
 			$responseAppName = $element['appid'];
-			PHPUnit_Framework_Assert::assertSame($appID, $responseAppName);
+			Assert::assertSame($appID, $responseAppName);
 		}
 	}
 
@@ -317,7 +318,7 @@ class TestingAppContext implements Context {
 			$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 			$lastOutputArray = \json_decode($lastOutput, true);
 			$actualAppEnabledStatus = $lastOutputArray['apps'][$appName]['enabled'];
-			PHPUnit_Framework_Assert::assertSame($appEnabled, $actualAppEnabledStatus);
+			Assert::assertSame($appEnabled, $actualAppEnabledStatus);
 		} else {
 			throw new \Exception("App enabled status could not be found in the response.");
 		}
@@ -358,7 +359,7 @@ class TestingAppContext implements Context {
 	 */
 	public function theAdministratorHasCreatedFileWithContent($path, $content) {
 		$this->theAdministratorCreatesFileUsingTheTestingApi($path, $content);
-		PHPUnit_Framework_Assert::assertSame(
+		Assert::assertSame(
 			200,
 			$this->featureContext->getResponse()->getStatusCode()
 		);
@@ -518,7 +519,7 @@ class TestingAppContext implements Context {
 	 */
 	public function theAdministratorHasCreatedANotification(TableNode $table) {
 		$this->theAdministratorCreatesANotification($table);
-		PHPUnit_Framework_Assert::assertSame(200, $this->featureContext->getResponse()->getStatusCode());
+		Assert::assertSame(200, $this->featureContext->getResponse()->getStatusCode());
 	}
 
 	/**
@@ -573,7 +574,7 @@ class TestingAppContext implements Context {
 	public function fileShouldHaveFileIdGreaterThanBitsForUser($path, $max, $user) {
 		$max_value = \bindec(\str_repeat("1", $max - 1));
 		$currentFileID = $this->featureContext->getFileIdForPath($user, $path);
-		PHPUnit_Framework_Assert::assertGreaterThan($max_value, (int)$currentFileID);
+		Assert::assertGreaterThan($max_value, (int)$currentFileID);
 	}
 
 	/**
@@ -623,7 +624,7 @@ class TestingAppContext implements Context {
 		$this->clearLogFile();
 		$this->getLogfile();
 		$finalCount = \count($this->featureContext->getResponseXml()->data[0]);
-		PHPUnit_Framework_Assert::assertLessThan($initialCount, $finalCount);
+		Assert::assertLessThan($initialCount, $finalCount);
 	}
 
 	/**
@@ -644,7 +645,7 @@ class TestingAppContext implements Context {
 			true
 		);
 		$expectedExtensions = \explode(', ', $extensions);
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedExtensions, $actualExtensions['element']
 		);
 	}

--- a/tests/unit/lib/BigFileIDTest.php
+++ b/tests/unit/lib/BigFileIDTest.php
@@ -14,7 +14,7 @@ use Test\TestCase;
  */
 class BigFileIDTest extends TestCase {
 	public function testBigId() {
-		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
+		/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject $logger */
 		$logger = $this->createMock(ILogger::class);
 		$logger->expects(self::once())
 			->method('warning')


### PR DESCRIPTION
## Description
1) Adjust PHPUnit Framework namespace for PHPUnit6 
2) phpunit enable failOnRisky failOnWarning 
3) Updating bamarni/composer-bin-plugin (v1.2.0 => v1.3.0)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)