### PR TITLE
Add notify step to drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -136,6 +136,15 @@ pipeline:
       matrix:
         TEST_SUITE: build
 
+  notify:
+    image: plugins/slack:1
+    pull: true
+    secrets: [slack_webhook]
+    channel: builds
+    when:
+      status: [failure, changed]
+      event: [push, tag]
+
 services:
   mysql:
     image: mysql:5.5


### PR DESCRIPTION
## Description
Add the missing `notify:` step to drone, so that fails on nightly drone runs will get reported.

Note: `slack_webhook` is already set up in drone for this repo.

 
## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)