### PR TITLE
Add api for checking if apache module is installed

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -21,6 +21,7 @@
 
 namespace OCA\Testing\AppInfo;
 
+use OCA\Testing\ApacheModules;
 use OCA\Testing\BigFileID;
 use OCA\Testing\Config;
 use OCA\Testing\DavSlowdown;
@@ -152,6 +153,16 @@ API::register(
 	'post',
 	'/apps/testing/api/v1/occ',
 	[$occ, 'execute'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+$apacheMod = new ApacheModules((\OC::$server->getRequest()));
+
+API::register(
+	'get',
+	'/apps/testing/api/v1/apache_modules/{module}',
+	[$apacheMod, 'getModule'],
 	'testing',
 	API::ADMIN_AUTH
 );

--- a/lib/ApacheModules.php
+++ b/lib/ApacheModules.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Saugat Pachhai <saugat@jankaritech.com>
+ * @copyright Copyright (c) 2019 Saugat Pachhai saugat@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OC\OCS\Result;
+use OCP\API;
+use OCP\IRequest;
+
+class ApacheModules {
+	/**
+	 *
+	 * @var IRequest
+	 */
+	private $request;
+
+	/**
+	 *
+	 * @param IRequest $request
+	 */
+	public function __construct(IRequest $request) {
+		$this->request = $request;
+	}
+
+	protected function isApache() {
+		return (\strpos($_SERVER['SERVER_SOFTWARE'], 'Apache') !== false);
+	}
+
+	protected function getModules() {
+		if (\function_exists("apache_get_modules")) {
+			return apache_get_modules();
+		}
+		return [];
+	}
+
+	/**
+	 *
+	 * @return Result
+	 */
+	public function getModule(array $parameters) {
+		$module = $parameters["module"];
+
+		if (!$this->isApache()) {
+			return new Result(null, API::RESPOND_NOT_FOUND, 'the server does not seem to be running behind Apache.');
+		}
+
+		if (\in_array($module, $this->getModules(), true)) {
+			return new Result(["message" => "$module is loaded in apache_modules."], 100, null);
+		}
+
+		return new Result(null, API::RESPOND_NOT_FOUND, "$module could not be found in apache_modules.");
+	}
+}

--- a/tests/acceptance/features/apiTestingApp/testing.feature
+++ b/tests/acceptance/features/apiTestingApp/testing.feature
@@ -139,7 +139,7 @@ Feature: Testing the testing app
     When the administrator gets all the extensions of mime-type "audio" using the testing API
     Then the extensions returned should be "flac, m4a, m4b, mp3, m3u, m3u8, oga, ogg, opus, pls, wav"
     And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"
     Examples:
       | ocs-api-version | ocs-status | http-status | http-reason-phrase |
@@ -151,9 +151,32 @@ Feature: Testing the testing app
     When the administrator gets all the extensions of mime-type "audio/ogg" using the testing API
     Then the extensions returned should be "oga, ogg, opus"
     And the HTTP reason phrase should be "<http-reason-phrase>"
-    And the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
     And the OCS status code should be "<ocs-status>"
     Examples:
       | ocs-api-version | ocs-status | http-status | http-reason-phrase |
       | 1               | 100        | 200         | OK                 |
       | 2               | 200        | 200         | OK                 |
+
+  Scenario Outline: Testing app returns success if the given apache module is loaded
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator checks if "core" apache module is installed using the testing API
+    Then the HTTP reason phrase should be "<http-reason-phrase>"
+    And the HTTP status code should be "<http-status>"
+    And the OCS status code should be "<ocs-status>"
+    Examples:
+      | ocs-api-version | ocs-status | http-status | http-reason-phrase |
+      | 1               | 100        | 200         | OK                 |
+      | 2               | 200        | 200         | OK                 |
+
+  Scenario Outline: Testing app returns failure if the given apache module is not loaded
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator checks if "random_module_123" apache module is installed using the testing API
+    Then the HTTP reason phrase should be "<http-reason-phrase>"
+    And the HTTP status code should be "<http-status>"
+    And the OCS status code should be "<ocs-status>"
+    And the OCS status message should be "<ocs-message>"
+    Examples:
+      | ocs-api-version | ocs-status | http-status | http-reason-phrase | ocs-message                                             |
+      | 1               | 998        | 200         | OK                 | random_module_123 could not be found in apache_modules. |
+      | 2               | 404        | 404         | Not Found          | random_module_123 could not be found in apache_modules. |

--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -837,6 +837,27 @@ class TestingAppContext implements Context {
 	}
 
 	/**
+	 * @When the administrator checks if :module apache module is installed using the testing API
+	 *
+	 * @param string $module
+	 *
+	 * @return void
+	 */
+	public function theAdministratorChecksIfApacheModIsInstalled($module) {
+		$adminUser = $this->featureContext->getAdminUsername();
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$adminUser,
+			$this->featureContext->getAdminPassword(),
+			'GET',
+			$this->getBaseUrl("/apache_modules/{$module}"),
+			[],
+			$this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * @Given the administrator has created following locks
 	 *
 	 * @param TableNode $table

--- a/tests/unit/lib/ApacheModulesTest.php
+++ b/tests/unit/lib/ApacheModulesTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace OCA\Testing\Tests\Unit\Lib;
+
+use OC\AppFramework\Http\Request;
+use OCA\Testing\ApacheModules;
+use Test\TestCase;
+
+/**
+ * Class ApacheModulesTest
+ *
+ * @package OCA\Testing\Tests\Unit\Lib
+ */
+class ApacheModulesTest extends TestCase {
+	public function setUp() {
+		parent::setUp();
+
+		$this->apacheModule = $this->getMockBuilder(ApacheModules::class)
+			->setConstructorArgs([new Request()])
+			->setMethods(['isApache', 'getModules'])
+			->getMock();
+	}
+
+	public function testWhenNotBehindApache() {
+		$this->apacheModule->expects($this->once())
+			->method('isApache')
+			->willReturn(false);
+
+		$result = $this->apacheModule->getModule(["module" => "core"]);
+
+		$this->assertEquals($result->getMeta(),
+			[
+				"message" => "the server does not seem to be running behind Apache.",
+				"statuscode" => 998,
+				'status' => 'failure'
+			]
+		);
+		$this->assertEmpty($result->getData());
+	}
+
+	public function testWhenBehindApacheAndAvailableModule() {
+		$this->apacheModule->expects($this->once())
+			->method('isApache')
+			->willReturn(true);
+		$this->apacheModule->expects($this->once())
+			->method('getModules')
+			->willReturn(['core', 'core2']);
+
+		$result = $this->apacheModule->getModule(["module" => "core"]);
+
+		$this->assertEquals($result->getMeta(),
+			[
+				"message" => null,
+				"statuscode" => 100,
+				'status' => 'ok'
+			]
+		);
+		$this->assertEquals($result->getData(), ["message" => "core is loaded in apache_modules."]);
+	}
+
+	public function testWhenBehindApacheAndNotAvailableModule() {
+		$this->apacheModule->expects($this->once())
+			->method('isApache')
+			->willReturn(true);
+		$this->apacheModule->expects($this->once())
+			->method('getModules')
+			->willReturn([]);
+
+		$result = $this->apacheModule->getModule(["module" => "core"]);
+
+		$this->assertEquals($result->getMeta(),
+			[
+				"message" => "core could not be found in apache_modules.",
+				"statuscode" => 998,
+				'status' => 'failure'
+			]
+		);
+		$this->assertEquals($result->getData(), []);
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This adds an API for checking if a given apache module is installed.

Currently, our testing setup requires `mod_rewrite` to be enabled for all tests to pass. Currently, we have no way to find that out. This is a generic solution that can check for *any* module that apache has enabled. 

I plan to use this to check for `mod_rewrite` is whether enabled or not in the core, and provide helpful message on our test runner.

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)