### PR TITLE
Add routes to add delete and retrieve trusted servers

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -41,7 +41,8 @@ return [
 		'lib',
 		'vendor',
 		'../../lib',
-		'../../core'
+		'../../core',
+		'../federation/lib'
 	],
 
 	// A directory list that defines files that will be excluded
@@ -58,7 +59,8 @@ return [
 	'exclude_analysis_directory_list' => [
 		'vendor',
 		'../../lib',
-		'../../core'
+		'../../core',
+		'../federation/lib'
 	],
 
 	// A regular expression to match files to be excluded

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -34,6 +34,7 @@ use OCA\Testing\ServerFiles;
 use OCA\Testing\SysInfo;
 use OCP\API;
 use OCA\Testing\TestingSkeletonDirectory;
+use OCA\Testing\TrustedServersHandler;
 
 $config = new Config(
 	\OC::$server->getConfig(),
@@ -299,6 +300,40 @@ API::register(
 	'post',
 	'/apps/testing/api/v1/testingskeletondirectory',
 	[$skeletonDirectory, 'set'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+$trustedServers = new TrustedServersHandler(\OC::$server->getRequest());
+
+API::register(
+	'get',
+	'/apps/testing/api/v1/trustedservers',
+	[$trustedServers, 'getTrustedServers'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+API::register(
+	'delete',
+	'/apps/testing/api/v1/trustedservers',
+	[$trustedServers, 'removeTrustedServer'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+API::register(
+	'delete',
+	'/apps/testing/api/v1/trustedservers/all',
+	[$trustedServers, 'removeAllTrustedServers'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+API::register(
+	'post',
+	'/apps/testing/api/v1/trustedservers',
+	[$trustedServers, 'addTrustedServer'],
 	'testing',
 	API::ADMIN_AUTH
 );

--- a/lib/TrustedServersHandler.php
+++ b/lib/TrustedServersHandler.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @author Dipak Acharya<dipak@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OCA\Federation\TrustedServers;
+use OCP\IRequest;
+use OC\OCS\Result;
+use OCA\Federation\DbHandler;
+
+/**
+ * controller for TrustedServer testing
+ *
+ */
+class TrustedServersHandler {
+
+	/**
+	 * @var IRequest
+	 */
+	private $request;
+
+	/**
+	 * @var TrustedServers
+	 */
+	private $trustedServers;
+
+	/**
+	 * @param IRequest $request
+	 */
+	public function __construct(IRequest $request) {
+		$this->request = $request;
+		$dbHandler = new DbHandler(\OC::$server->getDatabaseConnection(), \OC::$server->getL10N('federation'));
+		$this->trustedServers = new TrustedServers(
+				$dbHandler,
+				\OC::$server->getHTTPClientService(),
+				\OC::$server->getLogger(),
+				\OC::$server->getJobList(),
+				\OC::$server->getSecureRandom(),
+				\OC::$server->getConfig(),
+				\OC::$server->getEventDispatcher()
+		);
+	}
+
+	/**
+	 * Get the list of trusted owncloud servers
+	 *
+	 * @return \OC\OCS\Result
+	 */
+	public function getTrustedServers() {
+		$servers = $this->trustedServers->getServers();
+
+		return new Result($servers, 100, null);
+	}
+
+	/**
+	 * Remove a server from the trusted servers
+	 *
+	 * @return \OC\OCS\Result
+	 */
+	public function removeTrustedServer() {
+		$url = $this->request->getParam('url');
+
+		$servers = $this->trustedServers->getServers();
+		foreach ($servers as $server) {
+			if ($server["url"] === $url) {
+				$this->trustedServers->removeServer($server["id"]);
+				return new Result(null, 204);
+			}
+		}
+		return new Result(null, 404, "Could not find $url in trusted servers");
+	}
+
+	/**
+	 * Remove all server from the trusted servers
+	 *
+	 * @return \OC\OCS\Result
+	 */
+	public function removeAllTrustedServers() {
+		$servers = $this->trustedServers->getServers();
+		foreach ($servers as $server) {
+			$this->trustedServers->removeServer($server['id']);
+		}
+		return new Result(null, 204, null);
+	}
+
+	/**
+	 * Add given server to the list of trusted server
+	 *
+	 * @return \OC\OCS\Result
+	 */
+	public function addTrustedServer() {
+		$url = $this->request->getParam('url');
+
+		$this->trustedServers->addServer($url);
+		return new Result(null, 201);
+	}
+}

--- a/lib/TrustedServersHandler.php
+++ b/lib/TrustedServersHandler.php
@@ -102,7 +102,7 @@ class TrustedServersHandler {
 	}
 
 	/**
-	 * Add given server to the list of trusted server
+	 * Add given server to the list of trusted servers
 	 *
 	 * @return \OC\OCS\Result
 	 */

--- a/tests/acceptance/features/apiTestingApp/trustedServer.feature
+++ b/tests/acceptance/features/apiTestingApp/trustedServer.feature
@@ -1,0 +1,53 @@
+@api
+Feature: Test trusted server feature of testing app
+
+  Scenario Outline: Add new trusted server using the testing api
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator adds url "http://new-oc.com" as trusted server using the testing API
+    Then the HTTP status code should be "<http-status>"
+    And the HTTP reason phrase should be "<http-reason-phrase>"
+    And the OCS status code should be "<ocs-status>"
+    And url "http://new-oc.com" should be a trusted server
+    Examples:
+      | ocs-api-version | ocs-status | http-status | http-reason-phrase |
+      | 1               | 201        | 201         | Created            |
+      | 2               | 201        | 201         | Created            |
+
+  Scenario Outline: Add multiple trusted servers using the testing api
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator adds url "http://new-oc.com" as trusted server using the testing API
+    When the administrator adds url "http://new-oc1.com" as trusted server using the testing API
+    When the administrator adds url "http://aafnobadal.com" as trusted server using the testing API
+    Then the trusted server list should include these urls:
+      | url                         |
+      | http://new-oc.com           |
+      | http://new-oc1.com          |
+      | http://aafnobadal.com       |
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  Scenario Outline: Delete trusted servers using the testing api
+    Given using OCS API version "<ocs-api-version>"
+    And the administrator has added url "http://new-oc.com" as trusted server
+    When the administrator deletes url "http://new-oc.com" from trusted servers using the testing API
+    Then the HTTP status code should be "<http-status>"
+    And url "http://new-oc.com" should not be a trusted server
+    Examples:
+      | ocs-api-version | http-status |
+      | 1               | 204         |
+      | 2               | 204         |
+
+  Scenario Outline: Delete all trusted servers using the testing api
+    Given using OCS API version "<ocs-api-version>"
+    And the administrator has added url "http://new-oc.com" as trusted server
+    And the administrator has added url "http://new-oc1.com" as trusted server
+    And the administrator has added url "http://aafnobadal.com" as trusted server
+    When the administrator deletes all trusted servers using the testing API
+    Then the HTTP status code should be "<http-status>"
+    And the trusted server list should be empty
+    Examples:
+      | ocs-api-version | http-status |
+      | 1               | 204         |
+      | 2               | 204         |


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add routes to add, delete and list trusted owncloud servers using the testing app.

Related issue https://github.com/owncloud/core/issues/34742
Fixes #102

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)