### PR TITLE
Use only 1 var in when matrix of drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ pipeline:
       - apps/testing
     version: ${OC_VERSION}
     db_type: ${DB_TYPE}
-    db_name: ${DB_NAME=owncloud}
+    db_name: ${DB_NAME}
     db_host: ${DB_TYPE}
     db_username: autotest
     db_password: owncloud
@@ -170,7 +170,7 @@ services:
     environment:
       - MYSQL_USER=autotest
       - MYSQL_PASSWORD=owncloud
-      - MYSQL_DATABASE=${DB_NAME=owncloud}
+      - MYSQL_DATABASE=${DB_NAME}
       - MYSQL_ROOT_PASSWORD=owncloud
     when:
       matrix:
@@ -181,7 +181,7 @@ services:
     environment:
       - POSTGRES_USER=autotest
       - POSTGRES_PASSWORD=owncloud
-      - POSTGRES_DB=${DB_NAME=owncloud}
+      - POSTGRES_DB=${DB_NAME}
     when:
       matrix:
         DB_TYPE: pgsql
@@ -191,7 +191,7 @@ services:
     environment:
       - ORACLE_USER=system
       - ORACLE_PASSWORD=oracle
-      - ORACLE_DB=${DB_NAME=owncloud}
+      - ORACLE_DB=${DB_NAME}
     when:
       matrix:
         DB_TYPE: oci
@@ -235,12 +235,14 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit
       DB_TYPE: mysql
+      DB_NAME: owncloud
       NEED_CORE: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit
       DB_TYPE: pgsql
+      DB_NAME: owncloud
       NEED_CORE: true
 
     - PHP_VERSION: 7.1
@@ -254,6 +256,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit
       DB_TYPE: mysql
+      DB_NAME: owncloud
       NEED_CORE: true
       PHAN: true
 
@@ -261,6 +264,7 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit
       DB_TYPE: mysql
+      DB_NAME: owncloud
       NEED_CORE: true
       PHAN: true
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -105,7 +105,6 @@ pipeline:
       - make test-php-phan
     when:
       matrix:
-        TEST_SUITE: phpunit
         PHAN: true
 
   phpunit-tests:


### PR DESCRIPTION
## Description
1) The new drone tries to auto-convert the old drone format. It seems that when there are multiple variables mentioned in the `when` section of a step, it it doing something in the auto-conversion that causes:

`linter: duplicate step names`

I guess that it might be putting the step twice into the converted matrix.

The changes in this PR work-around the "feature".

2) Specify `DB_NAME` in every matrix entry.
`db_name: ${DB_NAME=owncloud}` is not being converted automatically for the new drone.


## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)