### PR TITLE
Add all params for drone matrix

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -113,7 +113,7 @@ pipeline:
     environment:
       - COVERAGE=${COVERAGE}
     commands:
-      - if [ -z "${COVERAGE}" ]; then make test-php-unit; fi
+      - if [ "${COVERAGE}" = "false" ]; then make test-php-unit; fi
       - if [ "${COVERAGE}" = "true" ]; then make test-php-unit-dbg; fi
     when:
       matrix:
@@ -216,6 +216,8 @@ matrix:
     - PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpstan
+      DB_TYPE: sqlite
+      DB_NAME: owncloud
       NEED_CORE: true
       NEED_INSTALL_APP: true
 
@@ -228,8 +230,10 @@ matrix:
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit
       DB_TYPE: sqlite
+      DB_NAME: owncloud
       NEED_CORE: true
       PHAN: true
+      COVERAGE: false
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -237,6 +241,7 @@ matrix:
       DB_TYPE: mysql
       DB_NAME: owncloud
       NEED_CORE: true
+      COVERAGE: false
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -244,6 +249,7 @@ matrix:
       DB_TYPE: pgsql
       DB_NAME: owncloud
       NEED_CORE: true
+      COVERAGE: false
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
@@ -251,6 +257,7 @@ matrix:
       DB_TYPE: oci
       DB_NAME: XE
       NEED_CORE: true
+      COVERAGE: false
 
     - PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa
@@ -259,6 +266,7 @@ matrix:
       DB_NAME: owncloud
       NEED_CORE: true
       PHAN: true
+      COVERAGE: false
 
     - PHP_VERSION: 7.3
       OC_VERSION: daily-master-qa
@@ -267,6 +275,7 @@ matrix:
       DB_NAME: owncloud
       NEED_CORE: true
       PHAN: true
+      COVERAGE: false
 
     - PHP_VERSION: 7.0
       OC_VERSION: daily-master-qa
@@ -275,6 +284,7 @@ matrix:
       DB_NAME: owncloud
       NEED_CORE: true
       PHAN: true
+      COVERAGE: false
 
     # Acceptance Tests
     - PHP_VERSION: 7.1
@@ -286,6 +296,7 @@ matrix:
       NEED_CORE: true
       NEED_SERVER: true
       NEED_INSTALL_APP: true
+      USE_RELEASE_TARBALL: false
 
     - PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa
@@ -296,6 +307,7 @@ matrix:
       NEED_CORE: true
       NEED_SERVER: true
       NEED_INSTALL_APP: true
+      USE_RELEASE_TARBALL: false
 
     - PHP_VERSION: 7.0
       OC_VERSION: daily-master-qa
@@ -306,6 +318,7 @@ matrix:
       NEED_CORE: true
       NEED_SERVER: true
       NEED_INSTALL_APP: true
+      USE_RELEASE_TARBALL: false
 
   # Acceptance tests against latest stable release of core
     - PHP_VERSION: 7.1


### PR DESCRIPTION
## Description
Explicitly mention all params needed by each drone matrix entry:
- always mention `DB_TYPE`  and `DB_NAME`
- for unit tests, always mention `COVERAGE`
- for acceptance tests, always mention `USE_RELEASE_TARBALL`

This avoids any problems when `drone convert --save` is run, and would not be able to find explicit values for some parameters.

(Then I will do `drone convert --save` in the next PR...)

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)