### PR TITLE
Do not fail if Federation app is not enabled

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -310,33 +310,37 @@ $trustedServers = new TrustedServersHandler(\OC::$server->getRequest());
 API::register(
 	'get',
 	'/apps/testing/api/v1/trustedservers',
-	[$trustedServers, 'getTrustedServers'],
+	[$trustedServers, 'defaultHandler'],
 	'testing',
-	API::ADMIN_AUTH
+	API::ADMIN_AUTH,
+	['getTrustedServers']
 );
 
 API::register(
 	'delete',
 	'/apps/testing/api/v1/trustedservers',
-	[$trustedServers, 'removeTrustedServer'],
+	[$trustedServers, 'defaultHandler'],
 	'testing',
-	API::ADMIN_AUTH
+	API::ADMIN_AUTH,
+	['removeTrustedServer']
 );
 
 API::register(
 	'delete',
 	'/apps/testing/api/v1/trustedservers/all',
-	[$trustedServers, 'removeAllTrustedServers'],
+	[$trustedServers, 'defaultHandler'],
 	'testing',
-	API::ADMIN_AUTH
+	API::ADMIN_AUTH,
+	['removeAllTrustedServers']
 );
 
 API::register(
 	'post',
 	'/apps/testing/api/v1/trustedservers',
-	[$trustedServers, 'addTrustedServer'],
+	[$trustedServers, 'defaultHandler'],
 	'testing',
-	API::ADMIN_AUTH
+	API::ADMIN_AUTH,
+	['addTrustedServer']
 );
 
 // files properties (working with the *properties table)

--- a/tests/acceptance/features/apiTestingApp/trustedServer.feature
+++ b/tests/acceptance/features/apiTestingApp/trustedServer.feature
@@ -1,4 +1,4 @@
-@api
+@api @federation-app-required
 Feature: Test trusted server feature of testing app
 
   Scenario Outline: Add new trusted server using the testing api


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Currently, if federation app gets disabled, the classes cannot be imported into the namespace,
and the server starts failing (but gives 200 response). This adds a handler that will return a better response if the federation app is disabled.
 
Fixes #117 

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)