### PR TITLE
move function to "set last login date" to feature context

### DIFF
--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -775,28 +775,6 @@ class TestingAppContext implements Context {
 	}
 
 	/**
-	 * @When the administrator sets the last login date for user :arg1 to :arg2 days ago using the testing API
-	 *
-	 * @param string $user
-	 * @param string $days
-	 *
-	 * @return void
-	 */
-	public function theAdministratorSetsTheLastLoginDateForUserToDaysAgoUsingTheTestingApi($user, $days) {
-		$adminUser = $this->featureContext->getAdminUsername();
-		$response = OcsApiHelper::sendRequest(
-			$this->featureContext->getBaseUrl(),
-			$adminUser,
-			$this->featureContext->getAdminPassword(),
-			'POST',
-			$this->getBaseUrl("/lastlogindate/{$user}"),
-			['days' => $days],
-			$this->featureContext->getOcsApiVersion()
-		);
-		$this->featureContext->setResponse($response);
-	}
-
-	/**
 	 * @Given the administrator has created a lock for the file :path with the type :type for user :user
 	 *
 	 * @param string $path


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR removes function theAdministratorSetsTheLastLoginDateForUserToDaysAgoUsingTheTestingApi() as it is added in `featureContext`.
This PR is half of PR https://github.com/owncloud/core/pull/36773
On top of : https://github.com/owncloud/testing/pull/132
## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)