### PR TITLE
[Tests-Only] Removing preg_rep from method listFiles

### DIFF
--- a/lib/ServerFiles.php
+++ b/lib/ServerFiles.php
@@ -224,7 +224,7 @@ class ServerFiles {
 				);
 				foreach ($ri as $file) {
 					if ($file->isFile()) {
-						$result[] = \preg_replace('/..[^d][0-9]{9}/', "", $file->getFilename());
+						$result[] =$file->getFilename();
 					}
 				}
 			}


### PR DESCRIPTION
## Description
As we will be requiring timestamp value in fileName so removing preg_replace from method `listFiles` in `ServerFiles.php` as we won't be using it.

## Related Issue
#139 

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)