### PR TITLE
Replace deprecated assertRegexp with assertMatchesRegularExpression

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -57,7 +57,6 @@ config = {
 				'apiTestingApp',
 			],
 			'phpVersions': [
-				'7.2',
 				'7.3',
 			],
 		},

--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -212,7 +212,7 @@ class TestingAppContext implements Context {
 		$data = \json_decode(\json_encode($responseXml->data[0]), 1);
 
 		Assert::assertInternalType('string', $data['server_root']);
-		Assert::assertRegExp('/[^\0]+/', $data['server_root']);
+		Assert::assertMatchesRegularExpression('/[^\0]+/', $data['server_root']);
 	}
 
 	/**

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "7.2"
+            "php": "7.3"
         }
     },
     "require": {

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -16,6 +16,6 @@
         "symfony/translation": "^4.4",
         "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^6.5",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.1"
     }
 }


### PR DESCRIPTION
## Description
`assertRegexp` is deprecated in phpunit9 and replaced by `assertMatchesRegularExpression`

Note: maybe work out how to make this sort of "change for the future" while still running phpunit 8

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)