### PR TITLE
[Tests-Only] Revert "Only test with PHP 7.4 against daily-master-qa"

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -59,16 +59,6 @@ config = {
 			'phpVersions': [
 				'7.2',
 				'7.3',
-			],
-		},
-		'api74': {
-			'suites': [
-				'apiTestingApp',
-			],
-			'servers': [
-				'daily-master-qa',
-			],
-			'phpVersions': [
 				'7.4',
 			],
 		},


### PR DESCRIPTION
## Description
This reverts commit 4a87ade4870d8208ba592a7e442a08c87d20d92e.

core `latest` is now a 10.5.0 tarball, so we can test against it.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)