### PR TITLE
Add api route to run multiple occ commands at once

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -160,6 +160,14 @@ API::register(
 	API::ADMIN_AUTH
 );
 
+API::register(
+	'post',
+	'/apps/testing/api/v1/occ/bulkset',
+	[$occ, 'bulkSet'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
 $apacheMod = new ApacheModules((\OC::$server->getRequest()));
 
 API::register(

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -162,8 +162,8 @@ API::register(
 
 API::register(
 	'post',
-	'/apps/testing/api/v1/occ/bulkset',
-	[$occ, 'bulkSet'],
+	'/apps/testing/api/v1/occ/bulk',
+	[$occ, 'bulkOccExecute'],
 	'testing',
 	API::ADMIN_AUTH
 );

--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -119,7 +119,7 @@ class Occ {
 	 *
 	 * @return Result
 	 */
-	public function bulkSet() {
+	public function bulkOccExecute() {
 		$data = \json_decode(\file_get_contents('php://input'), true);
 		$results = [];
 		$highCode = 100;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add new endpoint `'/apps/testing/api/v1/occ/bulkset'` to run a list of occ commands at once
```
POST /ocs/v2.php/apps/testing/api/v1/occ/bulkset HTTP/1.1

[
  {
    "command": "config:system:set --type=string --value=\"test\" testconfig"
  },
  {
    "command": "config:system:set --type=json --value=\"test2\" testconfig2"
  }
]
```

Response:
```
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>200</statuscode>
  <message/>
 </meta>
 <data>
  <element>
   <code>0</code>
   <stdOut>System config value testconfig set to string &quot;test&quot;
</stdOut>
   <stdErr></stdErr>
  </element>
  <element>
   <code>0</code>
   <stdOut>System config value testconfig2 set to json &quot;test2&quot;
</stdOut>
   <stdErr></stdErr>
  </element>
 </data>
</ocs>
```

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)