### PR TITLE
Refactor and add tests for occ/bulk endpoint

### DIFF
--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -127,11 +127,17 @@ class Occ {
 			if (!\array_key_exists("command", $item)) {
 				return new Result(null, 405, "Invalid format for the data, please check!");
 			}
-			if (\array_key_exists("env_variables", $item) && !\is_array($item['env_variables'])) {
-				return new Result(null, 405, "Invalid format for the data, please check!");
+			if (\array_key_exists("env_variables", $item)) {
+				if (\is_array($item['env_variables'])) {
+					$envVariables = $item['env_variables'];
+				} else {
+					return new Result(null, 405, "Invalid format for the data, please check!");
+				}
+			} else {
+				$envVariables = [];
 			}
 
-			$result = $this->runCommand($item["command"], $item["env_variables"]);
+			$result = $this->runCommand($item["command"], $envVariables);
 			\array_push($results, $result);
 			if ($result['code'] + 100 > $highCode) {
 				$highCode = $result["code"] + 100;

--- a/tests/acceptance/features/apiTestingApp/testing.feature
+++ b/tests/acceptance/features/apiTestingApp/testing.feature
@@ -134,6 +134,24 @@ Feature: Testing the testing app
       | 1               | 100        | 200         | OK                 |
       | 2               | 200        | 200         | OK                 |
 
+  Scenario Outline: Testing app can run occ commands in bulk
+    Given using OCS API version "<ocs-api-version>"
+    And app "comments" has been enabled
+    And app "notifications" has been disabled
+    When the administrator runs these occ commands in bulk using the testing API
+      | command                  |
+      | app:disable comments     |
+      | app:enable notifications |
+    Then the HTTP status code should be "<http-status>"
+    And the HTTP reason phrase should be "<http-reason-phrase>"
+    And the OCS status code should be "<ocs-status>"
+    And app "comments" should be disabled
+    And app "notifications" should be enabled
+    Examples:
+      | ocs-api-version | ocs-status | http-status | http-reason-phrase |
+      | 1               | 100        | 200         | OK                 |
+      | 2               | 200        | 200         | OK                 |
+
   Scenario Outline: Testing app returns all the extensions of a mime type
     Given using OCS API version "<ocs-api-version>"
     When the administrator gets all the extensions of mime-type "audio" using the testing API

--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -490,6 +490,46 @@ class TestingAppContext implements Context {
 	}
 
 	/**
+	 * @param array $commands
+	 *
+	 * @return void
+	 */
+	public function runBulkOccCommandUsingTestingAPI($commands) {
+		$user = $this->featureContext->getAdminUsername();
+		$commandsBody = [];
+		foreach ($commands as $command) {
+			$commandsBody[] = ['command' => $command];
+		}
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$this->featureContext->getAdminPassword(),
+			'POST',
+			$this->getBaseUrl("/occ/bulk"),
+			\json_encode($commandsBody),
+			$this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @When the administrator runs these occ commands in bulk using the testing API
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function theAdministratorRunsTheseOccCommandsInBulkUsingTheTestingApi(
+		TableNode $table
+	) {
+		$commands = [];
+		foreach ($table as $item) {
+			$commands[] = $item['command'];
+		}
+		$this->runBulkOccCommandUsingTestingAPI($commands);
+	}
+
+	/**
 	 * @When the administrator creates a notification with the following details using the testing API
 	 *
 	 * @param TableNode $table


### PR DESCRIPTION
## Description
When I tried the `occ/bulk` endpoint I saw that the server got PHP
```
[Thu Feb 18 10:59:15 2021] Undefined index: env_variables at /home/phil/git/owncloud/core/apps-external/testing/lib/Occ.php#134
[Thu Feb 18 10:59:15 2021] array_merge(): Expected parameter 2 to be an array, null given at /home/phil/git/owncloud/core/apps-external/testing/lib/Occ.php#76
```

- refactor the code so that `$reqEnvVars` is always passed as an array to `runCommand`
- add a test scenario for this new endpoint

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)