### PR TITLE
Add tinySkeleton

### DIFF
--- a/data/tinySkeleton/.gitignore
+++ b/data/tinySkeleton/.gitignore
@@ -1,0 +1,7 @@
+# This file is a placeholder so that git will keep the tinySkeleton folder
+# In oC10 there is really no such thing as "without skeleton files"
+# If skeletondirectory is not defined in config.php then whatever is in
+# /core/skeleton is used as the skeleton.
+# tinySkeleton can be used by the acceptance tests as the nearest thing to
+#  "without skeleton files"
+# It will have just this .gitignore


### PR DESCRIPTION
## Description
See discussion in https://github.com/owncloud/core/issues/38607

oC10 does not really have "without skeleton files". If no skeleton directory is defined in config.php then the contents of `core/skeleton` are used as the skeleton for new users.

This PR adds `tinySkeleton`. There is just a placeholder `.gitignore` file in it. (Unfortunately, to commit a directory to git, the directory must contain at least 1 file). We can use this as the skeleton in acceptance tests whenever they specify "without skeleton files"

The objective is to be able to have a consistent file-system for "Alice", "Brian" etc when the acceptance test step specifies "without skeleton files". (Currently core git master and various release tarballs have different files in `core/skeleton` and that can cause inconsistencies in test results)

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)