### PR TITLE
Expire a share

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -37,6 +37,7 @@ use OCP\API;
 use OCA\Testing\TestingSkeletonDirectory;
 use OCA\Testing\TrustedServersHandler;
 use OCA\Testing\FilesProperties;
+use OCA\Testing\ExpireShare;
 
 $config = new Config(
 	\OC::$server->getConfig(),
@@ -387,6 +388,19 @@ API::register(
 	'get',
 	'/apps/testing/api/v1/lastlogindate/{user}',
 	[$date, 'getLastLoginDate'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+$expireShare = new ExpireShare(
+	\OC::$server->getRequest(),
+	\OC::$server->getShareManager()
+);
+
+API::register(
+	'post',
+	'/apps/testing/api/v1/expire-share/{share_id}',
+	[$expireShare, 'expireShare'],
 	'testing',
 	API::ADMIN_AUTH
 );

--- a/lib/ExpireShare.php
+++ b/lib/ExpireShare.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Kiran Parajuli <kiran@jankaritech.com>
+ * @copyright Copyright (c) 2021 Kiran Parajuli kiran@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use DateTime;
+use OC\OCS\Result;
+use OCP\IRequest;
+use OCP\Share\Exceptions\GenericShareException;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+
+class ExpireShare {
+
+	/**
+	 * @var IRequest
+	 */
+	private $request;
+
+	/** @var IManager */
+	private $shareManager;
+
+	/**
+	 * @param IRequest $request
+	 * @param IManager $shareManager
+	 */
+	public function __construct(
+		IRequest $request,
+		IManager $shareManager
+	) {
+		$this->request = $request;
+		$this->shareManager = $shareManager;
+	}
+
+	/**
+	 * @param mixed $id
+	 * @return IShare
+	 * @throws ShareNotFound
+	 */
+	private function getShareById($id) {
+		$share = null;
+		try {
+			$share = $this->shareManager->getShareById('ocinternal:'.$id);
+		} catch (ShareNotFound $e) {
+			if (!$this->shareManager->outgoingServer2ServerSharesAllowed()) {
+				throw new ShareNotFound();
+			}
+			$share = $this->shareManager->getShareById('ocFederatedSharing:' . $id);
+		}
+		return $share;
+	}
+
+	public function expireShare(array $param) {
+		$id = \trim($param["share_id"]);
+		if (!$this->shareManager->shareApiEnabled()) {
+			return new Result(null, 404, 'Share API is disabled');
+		}
+
+		try {
+			$share = $this->getShareById($id);
+			$original_date = $share->getExpirationDate();
+		} catch (ShareNotFound $e) {
+			return new Result(null, 404, 'Wrong share ID, share doesn\'t exist');
+		}
+		// set share expiration to a past datetime
+		$share->setExpirationDate(new \DateTime('yesterday'));
+		$new_date = $share->getExpirationDate();
+		try {
+			$this->shareManager->updateShare($share, true);
+		} catch (GenericShareException $e) {
+			return new Result(null, 400, 'Share expire failed');
+		}
+		$date = new DateTime();
+
+		return new Result([
+			"stime" => $date->getTimestamp(),
+			"share_id" => $id,
+			"original_date"=> $original_date->format('Y-m-d H:i:s'),
+			"new_date" => $new_date->format('Y-m-d H:i:s')
+		], 100, 'Share is now expired');
+	}
+}

--- a/tests/acceptance/features/apiTestingApp/expireShare.feature
+++ b/tests/acceptance/features/apiTestingApp/expireShare.feature
@@ -1,7 +1,7 @@
-@api
+@api @skipOnOcV10.6 @skipOnOcV10.7
 Feature: expire a share
 
-  Scenario:
+  Scenario: set a share to expire yesterday and verify that it is not accessible
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |

--- a/tests/acceptance/features/apiTestingApp/expireShare.feature
+++ b/tests/acceptance/features/apiTestingApp/expireShare.feature
@@ -1,0 +1,25 @@
+@api
+Feature: expire a share
+
+  Scenario:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "Alice" has created a share with settings
+      | path        | /textfile0.txt |
+      | shareType   | user           |
+      | shareWith   | Brian          |
+      | permissions | read,share     |
+      | expireDate  | +15 days       |
+    When the administrator expires the last created share using the testing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the fields of the last response should include
+      | original_date | +15 days  |
+      | new_date      | yesterday |
+    And user "Alice" should not see the share id of the last share
+    And user "Brian" should not see the share id of the last share
+    And as "Brian" file "/textfile0.txt" should not exist
+    And as "Alice" file "/textfile0.txt" should exist


### PR DESCRIPTION
## Description
- expire an existing share

  `endpoint`: `/apps/testing/api/v1/expire-share/{share_id}
  `method`: POST

  > sets share expiration date to `yesterday`

- test added


## Related Issue
- https://github.com/owncloud/core/issues/36550

## Motivation
- works after core PR https://github.com/owncloud/core/pull/38793