### PR TITLE
Drop PHP 7.2 in sonar-project.properties

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -14,14 +14,7 @@ config = {
     "branches": [
         "master",
     ],
-    "codestyle": {
-        "ordinary": {
-            "phpVersions": [
-                "7.3",
-                "7.4",
-            ],
-        },
-    },
+    "codestyle": True,
     "phpstan": True,
     "phan": False,
     "build": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,5 +29,5 @@ sonar.pullrequest.branch=${env.SONAR_PULL_REQUEST_BRANCH}
 sonar.pullrequest.key=${env.SONAR_PULL_REQUEST_KEY}
 
 # Properties specific to language plugins:
-sonar.php.coverage.reportPaths=results/clover-phpunit-php7.2-mariadb10.2.xml,results/clover-phpunit-php7.2-mysql8.0.xml,results/clover-phpunit-php7.2-postgres9.4.xml,results/clover-phpunit-php7.2-oracle.xml,results/clover-phpunit-php7.2-sqlite.xml
+sonar.php.coverage.reportPaths=results/clover-phpunit-php7.3-mariadb10.2.xml,results/clover-phpunit-php7.3-mysql8.0.xml,results/clover-phpunit-php7.3-postgres9.4.xml,results/clover-phpunit-php7.3-oracle.xml,results/clover-phpunit-php7.3-sqlite.xml
 sonar.javascript.lcov.reportPaths=results/lcov.info


### PR DESCRIPTION
## Description
I missed this in #183 
- Drop PHP 7.2 in sonar-project.properties
- tidy up the "codestyle" CI so that it does the default.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)