### PR TITLE
Add api endpoint for moving a file in server root

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -295,6 +295,14 @@ API::register(
 	API::ADMIN_AUTH
 );
 
+API::register(
+	'move',
+	'/apps/testing/api/v1/file',
+	[$serverFiles, 'moveFile'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
 $davSlowDown = new DavSlowdown();
 
 API::register(

--- a/lib/ServerFiles.php
+++ b/lib/ServerFiles.php
@@ -238,4 +238,40 @@ class ServerFiles {
 		}
 		return new Result($result);
 	}
+
+	/**
+	 * Move a file to different location or name in the server
+	 * 'source' is a file or directory to rename
+	 * 'target' is a path to rename the file to
+	 * e.g. 'apps2/myapp/appinfo'
+	 *
+	 * @return Result
+	 */
+	public function moveFile() {
+		$filePath = \trim($this->request->getParam('source'), '/');
+		$isAbsolutePath = \trim($this->request->getParam('absolute'));
+		if ($isAbsolutePath === 'true') {
+			$filePath = "/$filePath";
+		} else {
+			$filePath = \OC::$SERVERROOT . "/$filePath";
+		}
+
+		$fileTarget = \trim($this->request->getParam('target'), '/');
+		$isAbsolutePath = \trim($this->request->getParam('absolute'));
+		if ($isAbsolutePath === 'true') {
+			$fileTarget = "/$fileTarget";
+		} else {
+			$fileTarget = \OC::$SERVERROOT . "/$fileTarget";
+		}
+
+		if (\file_exists($filePath)) {
+			try {
+				rename($filePath, $fileTarget);
+				return new Result([]);
+			} catch (\Exception $e) {
+				return new Result(null, 500, $e->getMessage());
+			}
+		}
+		return new Result(null, 404, "$fileTarget does not exist");
+	}
 }

--- a/tests/acceptance/features/apiTestingApp/serverFiles.feature
+++ b/tests/acceptance/features/apiTestingApp/serverFiles.feature
@@ -40,3 +40,26 @@ Feature: Test ServerFiles feature of testing app
       | ocs-api-version |
       | 1               |
       | 2               |
+
+  Scenario Outline: Testing app can move a directory in server root
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator creates directory "data/lorem-dir" in server root using the testing API
+    And the administrator creates file "data/lorem-dir/loremfile.txt" with content "lorem ipsum" using the testing API
+    And the administrator moves directory "data/lorem-dir" to "data/new-lorem-dir" using the testing API
+    Then the file "data/lorem-dir" should not exist in the server root
+    Then the file "data/new-lorem-dir/loremfile.txt" with content "lorem ipsum" should exist in the server root
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  Scenario Outline: Testing app can rename a file in server root
+    Given using OCS API version "<ocs-api-version>"
+    And the administrator creates file "loremfile.txt" with content "lorem ipsum" using the testing API
+    And the administrator moves file "loremfile.txt" to "newLoremFile.txt" using the testing API
+    Then the file "loremfile.txt" should not exist in the server root
+    Then the file "newLoremFile.txt" with content "lorem ipsum" should exist in the server root
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |

--- a/tests/acceptance/features/apiTestingApp/serverFiles.feature
+++ b/tests/acceptance/features/apiTestingApp/serverFiles.feature
@@ -47,7 +47,7 @@ Feature: Test ServerFiles feature of testing app
     And the administrator creates file "data/lorem-dir/loremfile.txt" with content "lorem ipsum" using the testing API
     And the administrator moves directory "data/lorem-dir" to "data/new-lorem-dir" using the testing API
     Then the file "data/lorem-dir" should not exist in the server root
-    Then the file "data/new-lorem-dir/loremfile.txt" with content "lorem ipsum" should exist in the server root
+    And the file "data/new-lorem-dir/loremfile.txt" with content "lorem ipsum" should exist in the server root
     Examples:
       | ocs-api-version |
       | 1               |
@@ -58,7 +58,7 @@ Feature: Test ServerFiles feature of testing app
     And the administrator creates file "loremfile.txt" with content "lorem ipsum" using the testing API
     And the administrator moves file "loremfile.txt" to "newLoremFile.txt" using the testing API
     Then the file "loremfile.txt" should not exist in the server root
-    Then the file "newLoremFile.txt" with content "lorem ipsum" should exist in the server root
+    And the file "newLoremFile.txt" with content "lorem ipsum" should exist in the server root
     Examples:
       | ocs-api-version |
       | 1               |

--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -458,6 +458,32 @@ class TestingAppContext implements Context {
 	}
 
 	/**
+	 * @When the administrator moves directory/file :source to :target using the testing API
+	 *
+	 * @param string $source
+	 * @param string $target
+	 *
+	 * @return void
+	 */
+	public function theAdministratorMovesDirectoryToUsingTheTestingApi($source, $target) {
+		$user = $this->featureContext->getAdminUsername();
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$this->featureContext->getAdminPassword(),
+			'MOVE',
+			$this->getBaseUrl("/file"),
+			$this->featureContext->getStepLineRef(),
+			['source' => $source, 'target' => $target],
+			$this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+		if ($response->getStatusCode() === 200) {
+			\array_push($this->createdDirectoryPaths, $target);
+		}
+	}
+
+	/**
 	 * @When the administrator deletes directory :dir using the testing API
 	 *
 	 * @param string $dir


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add api endpoint for moving a file in server root.
Related issue https://github.com/owncloud/core/issues/39350, to make the mounted local external storage unavailable to the server by renaming the mount point.

### Usage
endpoint- http://<oc-endpoint>/ocs/v2.php/apps/testing/api/v1/file
params- 
  - source: the file/folder which is to be moved
  - target: the path to which the file/folder is to be moved

eg.
```bash
curl http://localhost/ocs/v2.php/apps/testing/api/v1/file\?source\=test.txt\&target\=hello.txt -XMOVE -u admin:admin
```

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)