### PR TITLE
[Tests-Only] enforce strict type checking in acceptace tests code

### DIFF
--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *
@@ -221,7 +221,7 @@ class TestingAppContext implements Context {
 	 */
 	public function theResponseShouldContainTheServerRoot():void {
 		$responseXml = $this->featureContext->getResponseXml();
-		$data = \json_decode(\json_encode($responseXml->data[0]), 1);
+		$data = \json_decode(\json_encode($responseXml->data[0]), true);
 
 		Assert::assertIsString($data['server_root']);
 		Assert::assertMatchesRegularExpression('/[^\0]+/', $data['server_root']);

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *


### PR DESCRIPTION
Related https://github.com/owncloud/QA/issues/694
- add strict type checking on acceptace test code

**note** this PR was generated by a automated script