### PR TITLE
Add sysconfig testing endpoint

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -32,6 +32,7 @@ use OCA\Testing\Notifications;
 use OCA\Testing\Occ;
 use OCA\Testing\Opcache;
 use OCA\Testing\ServerFiles;
+use OCA\Testing\SysConfig;
 use OCA\Testing\SysInfo;
 use OCP\API;
 use OCA\Testing\TestingSkeletonDirectory;
@@ -104,6 +105,35 @@ API::register(
 	'get',
 	'/apps/testing/api/v1/getextension/{type}/{subtype}',
 	[$config, 'getExtensionForMimeTypeSubType'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+$sysConfig = new SysConfig(
+	\OC::$server->getConfig(),
+	\OC::$server->getRequest()
+);
+
+API::register(
+	'post',
+	'/apps/testing/api/v1/sysconfig/{configkey}',
+	[$sysConfig, 'setSysConfigValue'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+API::register(
+	'delete',
+	'/apps/testing/api/v1/sysconfig/{configkey}',
+	[$sysConfig, 'deleteSysConfigValue'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+API::register(
+	'get',
+	'/apps/testing/api/v1/sysconfig/{configkey}',
+	[$sysConfig, 'getSysConfigValue'],
 	'testing',
 	API::ADMIN_AUTH
 );

--- a/lib/SysConfig.php
+++ b/lib/SysConfig.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OCP\IConfig;
+use OCP\IRequest;
+use OC\OCS\Result;
+
+/*
+ * This allows tests to set, change and delete system config settings that are
+ * stored in config/config.php without having to use the occ config:system commands
+ */
+class SysConfig {
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var IRequest */
+	private $request;
+
+	/**
+	 * @param IConfig $config
+	 * @param IRequest $request
+	 */
+	public function __construct(IConfig $config, IRequest $request) {
+		$this->config = $config;
+		$this->request = $request;
+	}
+
+	/**
+	 * @param array $parameters
+	 * @return Result
+	 */
+	public function setSysConfigValue(array $parameters): Result {
+		$configKey = $parameters['configkey'];
+
+		$textValue = $this->request->getParam('value');
+		$dataType = $this->request->getParam('type');
+		$value = $this->castValue($textValue, $dataType);
+		$this->config->setSystemValue($configKey, $value);
+
+		return new Result();
+	}
+
+	/**
+	 * @param array $parameters
+	 * @return Result
+	 */
+	public function deleteSysConfigValue(array $parameters): Result {
+		$configKey = $parameters['configkey'];
+
+		$this->config->deleteSystemValue($configKey);
+
+		return new Result();
+	}
+
+	/**
+	 * @param array $parameters
+	 * @return Result
+	 */
+	public function getSysConfigValue(array $parameters): Result {
+		$configKey = $parameters['configkey'];
+		
+		$value = $this->config->getSystemValue($configKey);
+		$result[] = [
+			'configkey' => $configKey,
+			'value' => $value,
+			'type' => \gettype($value)
+		];
+		return new Result($result);
+	}
+
+	/**
+	 * @param string $value
+	 * @param string $type
+	 * @return mixed
+	 * @throws \InvalidArgumentException
+	 */
+	protected function castValue(string $value, string $type) {
+		switch ($type) {
+			case 'integer':
+			case 'int':
+				if (!\is_numeric($value)) {
+					throw new \InvalidArgumentException('Non-numeric value specified');
+				}
+				return (int) $value;
+
+			case 'double':
+			case 'float':
+				if (!\is_numeric($value)) {
+					throw new \InvalidArgumentException('Non-numeric value specified');
+				}
+				return (double) $value;
+
+			case 'boolean':
+			case 'bool':
+				$value = \strtolower($value);
+				switch ($value) {
+					case 'true':
+						return true;
+
+					case 'false':
+						return false;
+
+					default:
+						throw new \InvalidArgumentException('Unable to parse value as boolean');
+				}
+
+			// no break
+			case 'null':
+				return null;
+
+			case 'string':
+				return (string) $value;
+
+			case 'json':
+				$decodedJson = \json_decode($value, true);
+				if ($decodedJson === null) {
+					throw new \InvalidArgumentException('Unable to parse value as json');
+				}
+				return $decodedJson;
+
+			default:
+				throw new \InvalidArgumentException('Invalid type');
+		}
+	}
+}

--- a/tests/acceptance/features/apiTestingApp/testing.feature
+++ b/tests/acceptance/features/apiTestingApp/testing.feature
@@ -91,6 +91,25 @@ Feature: Testing the testing app
       | 1               | 100        | 200         | OK                 |
       | 2               | 200        | 200         | OK                 |
 
+  Scenario Outline: Admin adds and deletes a system config key of various types
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator adds a system config key "testing42" with value "<value>" and type "<type>" using the testing API
+    Then the HTTP status code should be "<http-status>"
+    And the HTTP reason phrase should be "<http-reason-phrase>"
+    And the OCS status code should be "<ocs-status>"
+    And the system config key "testing42" should have value "<value>" with type "<type>"
+    When the administrator deletes the system config key "testing42" using the testing API
+    Then the HTTP status code should be "<http-status>"
+    And the HTTP reason phrase should be "<http-reason-phrase>"
+    And the OCS status code should be "<ocs-status>"
+    And the system config key "testing42" should have value "" with type "string"
+    Examples:
+      | value     | type    | ocs-api-version | ocs-status | http-status | http-reason-phrase |
+      | something | string  | 1               | 100        | 200         | OK                 |
+      | something | string  | 2               | 200        | 200         | OK                 |
+      | 987       | integer | 1               | 100        | 200         | OK                 |
+      | 987       | integer | 2               | 200        | 200         | OK                 |
+
   Scenario Outline: Testing app returns details about the app
     Given using OCS API version "<ocs-api-version>"
     Given app "comments" has been enabled

--- a/tests/acceptance/features/bootstrap/TestingAppContext.php
+++ b/tests/acceptance/features/bootstrap/TestingAppContext.php
@@ -198,6 +198,97 @@ class TestingAppContext implements Context {
 	}
 
 	/**
+	 * @When the administrator adds a system config key :key with value :value and type :type using the testing API
+	 *
+	 * @param string $key
+	 * @param string $value
+	 * @param string $type the data type - string, int, bool, float
+	 *
+	 * @return void
+	 */
+	public function theAdministratorAddsASystemConfigKeyWithValueAndTypeUsingTheTestingApi(
+		string $key,
+		string $value,
+		string $type
+	):void {
+		$user = $this->featureContext->getAdminUsername();
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$this->featureContext->getAdminPassword(),
+			'POST',
+			$this->getBaseUrl("/sysconfig/{$key}"),
+			$this->featureContext->getStepLineRef(),
+			["value" => $value, "type" => $type],
+			$this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @When the administrator deletes the system config key :key using the testing API
+	 *
+	 * @param string $key
+	 *
+	 * @return void
+	 */
+	public function theAdministratorDeletesTheSystemConfigKeyUsingTheTestingApi(
+		string $key
+	):void {
+		$user = $this->featureContext->getAdminUsername();
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$this->featureContext->getAdminPassword(),
+			'DELETE',
+			$this->getBaseUrl("/sysconfig/{$key}"),
+			$this->featureContext->getStepLineRef(),
+			[],
+			$this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @Then the system config key :key should have value :value with type :type
+	 *
+	 * @param string $key
+	 * @param string $value
+	 * @param string $type
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theSystemConfigKeyShouldHaveValueWithType(
+		string $key,
+		string $value,
+		string $type
+	):void {
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			'GET',
+			"/apps/testing/api/v1/sysconfig/$key",
+			$this->featureContext->getStepLineRef(),
+			[],
+			$this->featureContext->getOcsApiVersion()
+		);
+		$configkeyValue = (string) $this->featureContext->getResponseXml($response, __METHOD__)->data[0]->element->value;
+		Assert::assertEquals(
+			$value,
+			$configkeyValue,
+			"The system config key $key was expected to have value $value but got $configkeyValue"
+		);
+		$configkeyType = (string) $this->featureContext->getResponseXml($response, __METHOD__)->data[0]->element->type;
+		Assert::assertEquals(
+			$type,
+			$configkeyType,
+			"The system config key $key was expected to have type $type but got $configkeyType"
+		);
+	}
+
+	/**
 	 * @Then the last login date in the response should be :day days ago
 	 *
 	 * @param int $day


### PR DESCRIPTION
## Description
This adds a `sysconfig` testing endpoint. It lets a caller POST a config key (in the URL) and a value and type (string, integer etc.). The key is added or updated in `config/config.php`

Key values and types can be queried with GET and deleted with DELETE.

This will let us set system config keys without having to run the related occ command. It will help some test scenarios to avoid using the occ command.

Note: such scenarios will still not "work" when testing oCIS, because oCIS currently has no way to have an API that can change system settings on-the-fly. But that is a separate issue.

Note: this so far only allows setting one level of system config key/value. But that should be enough for many of the tests that just need to set a single key-value in the system config.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)