### PR TITLE
Improve the message when the share expiration date update fails

### DIFF
--- a/lib/ExpireShare.php
+++ b/lib/ExpireShare.php
@@ -79,7 +79,8 @@ class ExpireShare {
 		try {
 			$this->shareManager->updateShare($share, true);
 		} catch (GenericShareException $e) {
-			return new Result(null, 400, 'Share expire failed');
+			$exceptionMessage = $e->getMessage();
+			return new Result(null, 400, "Share expire failed: $exceptionMessage");
 		}
 		$date = new DateTime();
 


### PR DESCRIPTION
## Description
If "expire share" fails, then the caller of the testing API currently gets a message:
`Share expire failed`

which is not very helpful.

Also send the message that goes with the exception that happened in the API response.

I am working on a PR that changes some sharing behavior, and noticed that it will be nice to have this improvement.

Now I get a response body like:
```
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>400</statuscode>
  <message>Share expire failed: Cannot set the requested share permissions for textfile0.txt</message>
  </meta>
  <data/>
</ocs>
```

which gives a better clue about what might be going wrong.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)