### PR TITLE
[tests-only] [full-ci] Run phan with php 7.3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -47,7 +47,14 @@ config = {
     ],
     "codestyle": True,
     "phpstan": True,
-    "phan": False,
+    "phan": {
+        "multipleVersions": {
+            "phpVersions": [
+                DEFAULT_PHP_VERSION,
+                "7.3",
+            ],
+        },
+    },
     "build": {
         "configureTarOnTag": True,
     },

--- a/.drone.star
+++ b/.drone.star
@@ -369,6 +369,7 @@ def phan(ctx):
 
     default = {
         "phpVersions": [DEFAULT_PHP_VERSION],
+        "extraApps": {},
     }
 
     if "defaults" in config:
@@ -407,6 +408,7 @@ def phan(ctx):
                 },
                 "steps": skipIfUnchanged(ctx, "lint") +
                          installCore(ctx, "daily-master-qa", "sqlite", False) +
+                         installExtraApps(phpVersion, params["extraApps"], False) +
                          [
                              {
                                  "name": "phan",
@@ -1138,6 +1140,7 @@ def acceptance(ctx):
                              testConfig["extraSetup"] +
                              waitForServer(testConfig["federatedServerNeeded"]) +
                              waitForEmailService(testConfig["emailNeeded"]) +
+                             waitForSamba(testConfig["extraServices"]) +
                              fixPermissions(phpVersionForDocker, testConfig["federatedServerNeeded"], params["selUserNeeded"]) +
                              waitForBrowserService(testConfig["browser"]) +
                              [
@@ -1438,6 +1441,26 @@ def waitForEmailService(emailNeeded):
 
     return []
 
+def waitForSamba(extraServices):
+    foundSamba = False
+
+    for extraService in extraServices:
+        # each service entry should be a key-value dictionary that has at least a "name" key
+        # if there is a "samba" service specified, then we need to wait for it to start.
+        if (extraService["name"] == "samba"):
+            foundSamba = True
+
+    if (foundSamba):
+        return [{
+            "name": "wait-for-samba",
+            "image": OC_CI_WAIT_FOR,
+            "commands": [
+                "wait-for -it samba:139,samba:445 -t 300",
+            ],
+        }]
+
+    return []
+
 def ldapService(ldapNeeded):
     if ldapNeeded:
         return [{
@@ -1664,7 +1687,7 @@ def installTestrunner(ctx, phpVersion, useBundledApp):
         ] if not useBundledApp else []),
     }]
 
-def installExtraApps(phpVersion, extraApps):
+def installExtraApps(phpVersion, extraApps, enableExtraApps = True):
     commandArray = []
     for app, command in extraApps.items():
         commandArray.append("ls %s/apps/%s || git clone https://github.com/owncloud/%s.git %s/apps/%s" % (dir["testrunner"], app, app, dir["testrunner"], app))
@@ -1673,9 +1696,10 @@ def installExtraApps(phpVersion, extraApps):
             commandArray.append("cd %s/apps/%s" % (dir["server"], app))
             commandArray.append(command)
         commandArray.append("cd %s" % dir["server"])
-        commandArray.append("php occ a:l")
-        commandArray.append("php occ a:e %s" % app)
-        commandArray.append("php occ a:l")
+        if (enableExtraApps):
+            commandArray.append("php occ a:l")
+            commandArray.append("php occ a:e %s" % app)
+            commandArray.append("php occ a:l")
 
     if (commandArray == []):
         return []

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -40,9 +40,9 @@ return [
 		'appinfo',
 		'lib',
 		'vendor',
+		'../../apps/federation/lib',
 		'../../lib',
 		'../../core',
-		'../federation/lib'
 	],
 
 	// A directory list that defines files that will be excluded
@@ -58,9 +58,9 @@ return [
 	//       and `exclude_analysis_directory_list` arrays.
 	'exclude_analysis_directory_list' => [
 		'vendor',
+		'../../apps/federation/lib',
 		'../../lib',
 		'../../core',
-		'../federation/lib'
 	],
 
 	// A regular expression to match files to be excluded

--- a/lib/ApacheModules.php
+++ b/lib/ApacheModules.php
@@ -23,7 +23,6 @@ namespace OCA\Testing;
 
 use OC\OCS\Result;
 use OCP\API;
-use OCP\IRequest;
 
 class ApacheModules {
 	public function __construct() {

--- a/lib/Dav/SlowdownPlugin.php
+++ b/lib/Dav/SlowdownPlugin.php
@@ -82,6 +82,7 @@ class SlowdownPlugin extends ServerPlugin {
 		RequestInterface $request,
 		ResponseInterface $response
 	) {
+		/* @phan-suppress-next-line PhanTypeArraySuspiciousNullable */
 		$timeToSleep = $this->slowDownSettings[\strtoupper($request->getMethod())];
 		$this->logger->info("time to sleep $timeToSleep");
 		for ($i = 0; $i <= $timeToSleep; $i++) {

--- a/lib/ExpireShare.php
+++ b/lib/ExpireShare.php
@@ -24,7 +24,6 @@ namespace OCA\Testing;
 
 use DateTime;
 use OC\OCS\Result;
-use OCP\IRequest;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;

--- a/lib/Locking/FakeDBLockingProvider.php
+++ b/lib/Locking/FakeDBLockingProvider.php
@@ -52,6 +52,7 @@ class FakeDBLockingProvider extends \OC\Lock\DBLockingProvider {
 	public function releaseLock($path, $type) {
 		// we DONT keep shared locks till the end of the request
 		if ($type === self::LOCK_SHARED) {
+			/* @phan-suppress-next-line PhanDeprecatedFunction */
 			$this->db->executeUpdate(
 				'UPDATE `*PREFIX*file_locks` SET `lock` = 0 WHERE `key` = ? AND `lock` = 1',
 				[$path]
@@ -66,6 +67,7 @@ class FakeDBLockingProvider extends \OC\Lock\DBLockingProvider {
 	 * @return void
 	 */
 	public function releaseAllGlobally() {
+		/* @phan-suppress-next-line PhanDeprecatedFunction */
 		$this->db->executeUpdate(
 			'UPDATE `*PREFIX*file_locks` SET `lock` = 0'
 		);

--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -138,6 +138,7 @@ class Occ {
 				$envVariables = [];
 			}
 
+			/* @phan-suppress-next-line PhanTypeMismatchArgument */
 			$result = $this->runCommand($item["command"], $envVariables);
 			\array_push($results, $result);
 			if ($result['code'] + 100 > $highCode) {

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^5.2"
+        "phan/phan": "^5.4"
     }
 }


### PR DESCRIPTION
`phan` will report errors if any of the code is not compatible with PHP 7.3.

This app still supports PHP 7.3 when used with oC10 core 10.11 and earlier.
