### PR TITLE
chore: move to github workflows

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -56,9 +56,7 @@ config = {
     "codestyle": False,
     "phpstan": False,
     "phan": False,
-    "build": {
-        "configureTarOnTag": True,
-    },
+    "build": False,
     "javascript": False,
     "phpunit": False,
     "acceptance": {

--- a/.drone.star
+++ b/.drone.star
@@ -4,7 +4,7 @@ MINIO_MC = "minio/mc:RELEASE.2020-12-18T10-53-53Z"
 OC_CI_ALPINE = "owncloudci/alpine:latest"
 OC_CI_BAZEL_BUILDIFIER = "owncloudci/bazel-buildifier"
 OC_CI_CEPH = "owncloudci/ceph:tag-build-master-jewel-ubuntu-16.04"
-OC_CI_CORE = "owncloudci/core"
+OC_CI_CORE = "owncloudci/core:php83"
 OC_CI_DRONE_SKIP_PIPELINE = "owncloudci/drone-skip-pipeline"
 OC_CI_NODEJS = "owncloudci/nodejs:%s"
 OC_CI_ORACLE_XE = "owncloudci/oracle-xe:latest"
@@ -21,7 +21,7 @@ SELENIUM_STANDALONE_CHROME_DEBUG = "selenium/standalone-chrome-debug:3.141.59-ox
 SELENIUM_STANDALONE_FIREFOX_DEBUG = "selenium/standalone-firefox-debug:3.8.1"
 SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli"
 
-DEFAULT_PHP_VERSION = "7.4"
+DEFAULT_PHP_VERSION = "8.3"
 DEFAULT_NODEJS_VERSION = "14"
 
 # minio mc environment variables
@@ -53,14 +53,14 @@ config = {
     "branches": [
         "master",
     ],
-    "codestyle": True,
-    "phpstan": True,
-    "phan": True,
+    "codestyle": False,
+    "phpstan": False,
+    "phan": False,
     "build": {
         "configureTarOnTag": True,
     },
     "javascript": False,
-    "phpunit": True,
+    "phpunit": False,
     "acceptance": {
         "api": {
             "suites": [

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  APP_NAME: testing
+  PHP_VERSIONS: '["8.3"]'
+
+jobs:
+  get-vars:
+    runs-on: ubuntu-latest
+    outputs:
+      app-name: ${{ env.APP_NAME }}
+      php-versions: ${{ env.PHP_VERSIONS }}
+    steps:
+      - name: Set variables
+        run: |
+          echo "App name $APP_NAME"
+          echo "PHP versions string: $PHP_VERSIONS"
+
+  semantic-git-messages:
+    name: Commits
+    uses: owncloud/reusable-workflows/.github/workflows/semantic-git-message.yml@main
+
+  php-code-style:
+    name: PHP Code Style
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/php-codestyle.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      php-versions: ${{ needs.get-vars.outputs.php-versions }}
+
+  php-unit:
+    name: PHP Unit
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/php-unit.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      php-versions: ${{ needs.get-vars.outputs.php-versions }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,3 +54,13 @@ jobs:
     with:
       app-name: ${{ needs.get-vars.outputs.app-name }}
       php-versions: ${{ needs.get-vars.outputs.php-versions }}
+
+  build:
+    name: Build
+    needs:
+      - get-vars
+      - php-code-style
+      - php-unit
+    uses: owncloud/reusable-workflows/.github/workflows/build.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}

--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "owncloud/coding-standard": "^4.1"
+        "owncloud/coding-standard": "^5.0"
     }
 }


### PR DESCRIPTION
## Description
Move to github workflows.

The "build" and "acceptance" steps are still in drone. In addition, we'll try to keep compatibility with PHP 7.4 for now until we officially drop support.

Tests run with PHP 8.3 due to core supports only PHP 8.3 at master branch. App's code should still support PHP 7.4 for the time being. Codestyle 5.0 supports PHP 7.4 and 8.3; we'll update it to 5.3 when we drop support for PHP 7.4

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)