### PR TITLE
fix: handle UTF8 characters in commands

### DIFF
--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -97,7 +97,7 @@ class Occ {
 		];
 
 		$process = \proc_open(
-			'php console.php ' . $args,
+			'LANG=C.UTF-8 php console.php ' . $args,
 			$descriptor,
 			$pipes,
 			\realpath("../"),

--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -164,6 +164,11 @@ class Occ {
 	// Taken from https://github.com/symfony/process/blob/master/Process.php
 	private function getDefaultEnv() {
 		$env = [];
+		// Specify a default locale that supports UTF8 characters
+		// This allows any UTF8 characters in the command to be preserved.
+		// For example, group names in various scripts.
+		$env['LANG'] = 'C.UTF-8';
+		$env['LC_ALL'] = 'C.UTF-8';
 		foreach ($_SERVER as $k => $v) {
 			if (\is_string($v) && false !== $v = \getenv($k)) {
 				$env[$k] = $v;

--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -71,7 +71,7 @@ class Occ {
 		//     user:add
 		//     user1
 		//     --password-from-env
-
+		setlocale(LC_CTYPE, 'C.UTF-8');
 		$envVars = \array_merge($this->getDefaultEnv(), $reqEnvVars);
 		\preg_match_all("/\S*?'[^']*?'|\S+/", $command, $matches);
 		$args = $matches[0];

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -15,6 +15,8 @@ default:
             regularUserPassword: 123456
             ocPath: apps/testing/api/v1/occ
         - NotificationsCoreContext:
+        - OccContext:
+        - OccUsersGroupsContext:
 
   extensions:
     Cjm\Behat\StepThroughExtension: ~

--- a/tests/acceptance/features/apiTestingApp/testing.feature
+++ b/tests/acceptance/features/apiTestingApp/testing.feature
@@ -177,6 +177,24 @@ Feature: Testing the testing app
       | नेपाली      | Unicode group name                    |
 
 
+  Scenario: admin gets all the groups
+    Given group "0" has been created
+    And group "brand-new-group" has been created
+    And group "España" has been created
+    And group "España§àôœ€" has been created
+    And group "नेपाली" has been created
+    When the administrator gets the groups in JSON format using the occ command
+    Then the command should have been successful
+    And the groups returned by the occ command should be
+      | group           |
+      | España          |
+      | España§àôœ€     |
+      | नेपाली            |
+      | admin           |
+      | brand-new-group |
+      | 0               |
+
+
   Scenario Outline: Testing app can run occ commands in bulk
     Given using OCS API version "<ocs-api-version>"
     And app "comments" has been enabled

--- a/tests/acceptance/features/apiTestingApp/testing.feature
+++ b/tests/acceptance/features/apiTestingApp/testing.feature
@@ -165,18 +165,6 @@ Feature: Testing the testing app
       | 2               | 200        | 200         | OK                 |
 
 
-  Scenario Outline: Testing app can run occ commands with UTF8 characters
-    When the administrator creates group "<group_id>" using the occ command
-    Then the command should have been successful
-    And the command output should contain the text 'Created group "<group_id>"'
-    And group "<group_id>" should exist
-    Examples:
-      | group_id    | comment                               |
-      | simplegroup | nothing special here                  |
-      | España§àôœ€ | special European and other characters |
-      | नेपाली      | Unicode group name                    |
-
-
   Scenario: admin gets all the groups
     Given group "0" has been created
     And group "brand-new-group" has been created
@@ -193,6 +181,18 @@ Feature: Testing the testing app
       | admin           |
       | brand-new-group |
       | 0               |
+
+
+  Scenario Outline: Testing app can run occ commands with UTF8 characters
+    When the administrator creates group "<group_id>" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'Created group "<group_id>"'
+    And group "<group_id>" should exist
+    Examples:
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
 
   Scenario Outline: Testing app can run occ commands in bulk

--- a/tests/acceptance/features/apiTestingApp/testing.feature
+++ b/tests/acceptance/features/apiTestingApp/testing.feature
@@ -165,6 +165,18 @@ Feature: Testing the testing app
       | 2               | 200        | 200         | OK                 |
 
 
+  Scenario Outline: Testing app can run occ commands with UTF8 characters
+    When the administrator creates group "<group_id>" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'Created group "<group_id>"'
+    And group "<group_id>" should exist
+    Examples:
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
+
+
   Scenario Outline: Testing app can run occ commands in bulk
     Given using OCS API version "<ocs-api-version>"
     And app "comments" has been enabled


### PR DESCRIPTION
## Description
The GitHub workflow environment does not have any locale set, and that seems to be making it not process any UTF8 characters pass to the command.

That is a problem for CLI tests that execute `occ` commands with parameters that are UTF8 strings. For example, creating a group with a European name that needs the UTF8 character set.

This PR makes the testing app always set at least the C.UTF-8 locale to avoid this issue.

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)