### PR TITLE
fix: handle utf8 characters in commands

### DIFF
--- a/lib/Occ.php
+++ b/lib/Occ.php
@@ -72,6 +72,10 @@ class Occ {
 		//     user1
 		//     --password-from-env
 
+		// Explicitly set the locale to handle UTF-8 characters.
+		// This ensures that escapeshellarg will correctly process
+		// UTF-8 strings with various scripts or special European characters.
+		setlocale(LC_CTYPE, 'C.UTF-8');
 		$envVars = \array_merge($this->getDefaultEnv(), $reqEnvVars);
 		\preg_match_all("/\S*?'[^']*?'|\S+/", $command, $matches);
 		$args = $matches[0];

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -15,6 +15,8 @@ default:
             regularUserPassword: 123456
             ocPath: apps/testing/api/v1/occ
         - NotificationsCoreContext:
+        - OccContext:
+        - OccUsersGroupsContext:
 
   extensions:
     Cjm\Behat\StepThroughExtension: ~

--- a/tests/acceptance/features/apiTestingApp/testing.feature
+++ b/tests/acceptance/features/apiTestingApp/testing.feature
@@ -165,6 +165,36 @@ Feature: Testing the testing app
       | 2               | 200        | 200         | OK                 |
 
 
+  Scenario: admin gets all the groups
+    Given group "0" has been created
+    And group "brand-new-group" has been created
+    And group "España" has been created
+    And group "España§àôœ€" has been created
+    And group "नेपाली" has been created
+    When the administrator gets the groups in JSON format using the occ command
+    Then the command should have been successful
+    And the groups returned by the occ command should be
+      | group           |
+      | España          |
+      | España§àôœ€     |
+      | नेपाली            |
+      | admin           |
+      | brand-new-group |
+      | 0               |
+
+
+  Scenario Outline: Testing app can run occ commands with UTF8 characters
+    When the administrator creates group "<group_id>" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'Created group "<group_id>"'
+    And group "<group_id>" should exist
+    Examples:
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
+
+
   Scenario Outline: Testing app can run occ commands in bulk
     Given using OCS API version "<ocs-api-version>"
     And app "comments" has been enabled


### PR DESCRIPTION
## Description
Some tests of commands use arguments that are UTF-8 characters.
For example, there are test scenarios that test creating groups
that have a name in Nepali script, or contain European characters.
They run occ commands using PHP proc_open.

These need to have a locale set that supports UTF8.
Then escapeshellarg() will correctly process UTF8 strings.

Depending on the setup of the environment, the Apache server may
not have UTF8 support enabled. This is the case when running the
default Apache server in a GitHub workflow.

To be sure that these tests run correctly in any environment,
explicitly set the locale to C.UTF-8 before calling escapeshellarg().

Test scenarios from core that were failing are added here, to demonstrate that they now pass, and to prevent future regressions.

## Checklist:
- [ ] Latest changes are published according to [instructions in README.md](https://github.com/owncloud/testing#publish-latest-version-as-github-release)