### PR TITLE
fix: avoid Passing null to parameter is deprecated messages

### DIFF
--- a/lib/ExpireShare.php
+++ b/lib/ExpireShare.php
@@ -60,6 +60,9 @@ class ExpireShare {
 	}
 
 	public function expireShare(array $param) {
+		if (!\array_key_exists('share_id', $param)) {
+			return new Result(null, 400, 'Share Id not provided');
+		}
 		$id = \trim($param["share_id"]);
 		if (!$this->shareManager->shareApiEnabled()) {
 			return new Result(null, 404, 'Share API is disabled');

--- a/lib/LastLoginDate.php
+++ b/lib/LastLoginDate.php
@@ -61,6 +61,9 @@ class LastLoginDate {
 	 * @return Result
 	 */
 	public function setLastLoginDate($param) {
+		if (!\array_key_exists('user', $param)) {
+			return new Result(null, 400, 'User id not provided');
+		}
 		$user = \trim($param['user']);
 		try {
 			$account = $this->accountMapper->getByUid($user);
@@ -88,6 +91,9 @@ class LastLoginDate {
 	 * @return Result
 	 */
 	public function getLastLoginDate($param) {
+		if (!\array_key_exists('user', $param)) {
+			return new Result(null, 400, 'User id not provided');
+		}
 		$user = \trim($param['user']);
 		try {
 			$account = $this->accountMapper->getByUid($user);

--- a/lib/ServerFiles.php
+++ b/lib/ServerFiles.php
@@ -55,7 +55,10 @@ class ServerFiles {
 	 * @return Result
 	 */
 	public function mkDir() {
-		$dir = \trim($this->request->getParam('dir'), '/');
+		$dir = \trim($this->request->getParam('dir', ''), '/');
+		if ($dir === "") {
+			return new Result(null, 400, "cannot create dir, dir not specified");
+		}
 		$targetDir = \OC::$SERVERROOT . "/$dir";
 		if (!\file_exists($targetDir)) {
 			// Ask for the full mode, it will be masked by the current umask anyway
@@ -79,7 +82,7 @@ class ServerFiles {
 	 * @return Result
 	 */
 	public function rmDir() {
-		$dir = \trim($this->request->getParam('dir'), '/');
+		$dir = \trim($this->request->getParam('dir', ''), '/');
 		if ($dir === "") {
 			return new Result(null, 400, "cannot delete dir, no dir name given");
 		}
@@ -139,8 +142,11 @@ class ServerFiles {
 	 * @return Result
 	 */
 	public function readFile() {
-		$filePath = \trim($this->request->getParam('file'), '/');
-		$isAbsolutePath = \trim($this->request->getParam('absolute'));
+		$filePath = \trim($this->request->getParam('file', ''), '/');
+		if ($filePath === "") {
+			return new Result(null, 400, "cannot read file, file path not specified");
+		}
+		$isAbsolutePath = \trim($this->request->getParam('absolute', ''));
 		if ($isAbsolutePath === 'true') {
 			$targetFile = "/$filePath";
 		} else {
@@ -166,7 +172,10 @@ class ServerFiles {
 	 * @return Result
 	 */
 	public function createFile() {
-		$filePath = \trim($this->request->getParam('file'), '/');
+		$filePath = \trim($this->request->getParam('file', ''), '/');
+		if ($filePath === '') {
+			return new Result(null, 400, "cannot create file, file path not specified");
+		}
 		$content = $this->request->getParam('content');
 		$targetFile = \OC::$SERVERROOT . "/$filePath";
 		$result = \file_put_contents($targetFile, $content);
@@ -185,7 +194,7 @@ class ServerFiles {
 	 * @return Result
 	 */
 	public function deleteFile() {
-		$filePath = \trim($this->request->getParam('file'), '/');
+		$filePath = \trim($this->request->getParam('file', ''), '/');
 		if ($filePath === "") {
 			return new Result(null, 400, "cannot delete file, no file name given");
 		}
@@ -214,7 +223,7 @@ class ServerFiles {
 	 */
 	public function listFiles() {
 		$result = [];
-		$dir = \trim($this->request->getParam('dir'), '/');
+		$dir = \trim($this->request->getParam('dir', ''), '/');
 		if ($dir === "") {
 			return new Result(null, 400, "cannot list files in dir, no dir name given");
 		}
@@ -248,16 +257,22 @@ class ServerFiles {
 	 * @return Result
 	 */
 	public function moveFile() {
-		$filePath = \trim($this->request->getParam('source'), '/');
-		$isAbsolutePath = \trim($this->request->getParam('absolute'));
+		$filePath = \trim($this->request->getParam('source', ''), '/');
+		if ($filePath === "") {
+			return new Result(null, 400, "cannot move file, file path not specified");
+		}
+		$isAbsolutePath = \trim($this->request->getParam('absolute', ''));
 		if ($isAbsolutePath === 'true') {
 			$filePath = "/$filePath";
 		} else {
 			$filePath = \OC::$SERVERROOT . "/$filePath";
 		}
 
-		$fileTarget = \trim($this->request->getParam('target'), '/');
-		$isAbsolutePath = \trim($this->request->getParam('absolute'));
+		$fileTarget = \trim($this->request->getParam('target', ''), '/');
+		if ($fileTarget === "") {
+			return new Result(null, 400, "cannot move file, file target not specified");
+		}
+		$isAbsolutePath = \trim($this->request->getParam('absolute', ''));
 		if ($isAbsolutePath === 'true') {
 			$fileTarget = "/$fileTarget";
 		} else {

--- a/lib/TestingSkeletonDirectory.php
+++ b/lib/TestingSkeletonDirectory.php
@@ -58,7 +58,10 @@ class TestingSkeletonDirectory {
 	 * @return Result
 	 */
 	public function set() {
-		$directory = \trim($this->request->getParam('directory'), '/');
+		$directory = \trim($this->request->getParam('directory', ''), '/');
+		if ($directory === '') {
+			return new Result(null, 400, "cannot set skeleton directory, dir not specified");
+		}
 		$folder = Filesystem::normalizePath($directory, true);
 		if (Filesystem::isValidPath($folder) === false) {
 			return new Result(null, 400, "invalid folder name");


### PR DESCRIPTION
trim() in PHP8 requires a string to be passed. Passing null is deprecated, and a deprecation message is emitted.

For example:
trim(): Passing null to parameter #1 ($string) of type string is deprecated at \/var\/www\/html\/server\/apps\/testing\/lib\/ServerFiles.php#143

Avoid these by ensuring that the value passed to trim() is always a string. Return appropriate "Bad Request" 400 status in the cases where an expected value was not provided.

https://github.com/owncloud/core/actions/runs/29151644976/job/86542673266?pr=41676#logs had this sort of thing in the log file. It will be good to avoid cluttering the log file.